### PR TITLE
fix: Update Dockerfile with Node Compatibility

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forklaunch"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Launch faster with forklaunch"

--- a/cli/src/templates/application/Dockerfile
+++ b/cli/src/templates/application/Dockerfile
@@ -1,4 +1,4 @@
-{{#is_node}}FROM node:23-alpine{{/is_node}}{{#is_bun}}FROM oven/bun:1{{/is_bun}}
+{{#is_node}}FROM node:22-alpine{{/is_node}}{{#is_bun}}FROM oven/bun:1{{/is_bun}}
 
 # Set working directory
 WORKDIR /{{app_name}}
@@ -8,6 +8,8 @@ COPY . .
 
 # Install dependencies
 {{#is_node}}RUN npm install -g pnpm
+RUN apk update
+RUN apk add --no-cache libc6-compat
 RUN apk add --no-cache git
 RUN pnpm install{{/is_node}}{{#is_bun}}RUN bun install{{/is_bun}}
 {{#is_node}}


### PR DESCRIPTION
## What's Included:

* Fixes an issue where hyper-express was not running as microwebsockets only supported up to node 22.
* Additionally adds necessary library files to alpine based container.