### PR TITLE
feat(cli): enforce manifest cli_version with self-update + centralized precheck

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -21,6 +21,7 @@ Cargo.lock
 #.idea/
 
 tests/output
+output/
 
 forklaunch-*.tgz
 bin/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,3 +44,4 @@ dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 glob = "0.3.2"
 serde-envfile = "0.3.0"
 tempfile = "3.20.0"
+dirs = "5.0.1"

--- a/cli/src/core.rs
+++ b/cli/src/core.rs
@@ -27,5 +27,6 @@ pub(crate) mod template;
 pub(crate) mod token;
 pub(crate) mod tsconfig;
 pub(crate) mod universal_sdk;
+pub(crate) mod version_check;
 pub(crate) mod watermark;
 pub(crate) mod worker_type;

--- a/cli/src/core/base_path.rs
+++ b/cli/src/core/base_path.rs
@@ -5,12 +5,12 @@ use std::{
 
 use anyhow::{Context, Result};
 use clap::ArgMatches;
-use rustyline::{Editor, history::DefaultHistory};
+use rustyline::{history::DefaultHistory, Editor};
 use termcolor::StandardStream;
 
 use crate::{
     constants::ERROR_FAILED_TO_GET_CWD,
-    prompt::{ArrayCompleter, prompt_with_validation},
+    prompt::{prompt_with_validation, ArrayCompleter},
 };
 
 pub(crate) enum BasePathType {
@@ -87,6 +87,21 @@ fn find_base_path(
             return Some(base_path);
         }
         base_path = base_path.parent().unwrap().to_path_buf();
+    }
+    None
+}
+
+pub(crate) fn find_nearest_manifest_root_unbounded() -> Option<PathBuf> {
+    let mut base_path = current_dir().ok()?;
+    loop {
+        let manifest = base_path.join(".forklaunch").join("manifest.toml");
+        if manifest.exists() {
+            return Some(base_path);
+        }
+        match base_path.parent() {
+            Some(parent) => base_path = parent.to_path_buf(),
+            None => break,
+        }
     }
     None
 }

--- a/cli/src/core/version_check.rs
+++ b/cli/src/core/version_check.rs
@@ -1,0 +1,210 @@
+use std::{fs, io::Write, path::PathBuf, process::Command as OsCommand};
+
+use anyhow::{Context, Result};
+use clap::ArgMatches;
+use reqwest::blocking::Client;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::prompt::{ArrayCompleter, prompt_for_confirmation};
+
+use super::base_path::find_nearest_manifest_root_unbounded;
+
+#[derive(Debug)]
+pub(crate) enum VersionCheckOutcome {
+    SkipNoManifest,
+    SkipWhitelisted,
+    Ok,
+    ReexecNotSupported,
+}
+
+fn current_cli_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+fn parse_required_cli_version(manifest_root: &PathBuf) -> Option<String> {
+    let manifest_path = manifest_root.join(".forklaunch").join("manifest.toml");
+    let content = fs::read_to_string(&manifest_path).ok()?;
+    let value: toml::Value = toml::from_str(&content).ok()?;
+    value
+        .get("cli_version")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn platform_triple() -> Result<&'static str> {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        return Ok("darwin-aarch64");
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        return Ok("darwin-x86_64");
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        return Ok("linux-aarch64");
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        return Ok("linux-x86_64");
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        return Ok("windows-x86_64");
+    }
+    #[allow(unreachable_code)]
+    Err(anyhow::anyhow!("Unsupported platform"))
+}
+
+fn download_binary(required_version: &str) -> Result<PathBuf> {
+    let platform = platform_triple()?;
+    let artifact_name = if platform.starts_with("windows") {
+        format!("forklaunch-{}.exe", platform)
+    } else {
+        format!("forklaunch-{}", platform)
+    };
+    let url = format!(
+        "https://github.com/forklaunch/forklaunch-js/releases/download/cli-v{}/{}",
+        required_version, artifact_name
+    );
+
+    let dir = dirs::home_dir()
+        .map(|p| p.join(".forklaunch").join("bin"))
+        .context("Failed to resolve install directory")?;
+    fs::create_dir_all(&dir).ok();
+    let binary_path = if platform.starts_with("windows") {
+        dir.join("forklaunch.exe")
+    } else {
+        dir.join("forklaunch")
+    };
+
+    let client = Client::builder().build()?;
+    let mut resp = client.get(&url).send()?;
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "Failed to download forklaunch v{} ({}): HTTP {}",
+            required_version,
+            platform,
+            resp.status()
+        );
+    }
+    let mut file = fs::File::create(&binary_path)?;
+    std::io::copy(&mut resp, &mut file)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&binary_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&binary_path, perms)?;
+    }
+
+    // Create alias 'fl' on unix-like systems
+    #[cfg(not(target_os = "windows"))]
+    {
+        let alias_path = dir.join("fl");
+        if alias_path.exists() {
+            let _ = fs::remove_file(&alias_path);
+        }
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&binary_path, &alias_path).ok();
+    }
+
+    Ok(binary_path)
+}
+
+pub(crate) fn precheck_version(
+    matches: &ArgMatches,
+    subcommand: &str,
+) -> Result<VersionCheckOutcome> {
+    // Skip for init application specifically
+    if subcommand == "init" {
+        if let Some((child, _)) = matches.subcommand() {
+            if child == "application" {
+                return Ok(VersionCheckOutcome::SkipWhitelisted);
+            }
+        }
+    }
+
+    let Some(manifest_root) = find_nearest_manifest_root_unbounded() else {
+        return Ok(VersionCheckOutcome::SkipNoManifest);
+    };
+    let Some(required_version) = parse_required_cli_version(&manifest_root) else {
+        return Ok(VersionCheckOutcome::Ok);
+    };
+
+    let current = current_cli_version();
+    if current == required_version {
+        return Ok(VersionCheckOutcome::Ok);
+    }
+
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))?;
+    writeln!(
+        &mut stdout,
+        "This project requires forklaunch CLI v{}, but you are running v{}.",
+        required_version, current
+    )?;
+    stdout.reset()?;
+
+    let mut line_editor =
+        rustyline::Editor::<ArrayCompleter, rustyline::history::DefaultHistory>::new()?;
+    let confirm = prompt_for_confirmation(
+        &mut line_editor,
+        "Do you want to install the required version now? [y/n]: ",
+    )?;
+    if !confirm {
+        anyhow::bail!("Version mismatch. Aborting as per user choice.");
+    }
+
+    // Informative messages before/after install
+    let platform = platform_triple()?;
+    let mut stdout2 = StandardStream::stdout(ColorChoice::Always);
+    stdout2.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
+    writeln!(
+        &mut stdout2,
+        "Installing forklaunch CLI v{} for {}...",
+        required_version, platform
+    )?;
+    stdout2.reset()?;
+
+    let binary_path = download_binary(&required_version)?;
+
+    stdout2.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+    writeln!(
+        &mut stdout2,
+        "Installed forklaunch CLI v{} at {}",
+        required_version,
+        binary_path.display()
+    )?;
+    stdout2.reset()?;
+
+    // Attempt to re-exec the command via the newly downloaded binary
+    stdout2.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
+    writeln!(
+        &mut stdout2,
+        "Re-executing your command with forklaunch v{}...",
+        required_version
+    )?;
+    stdout2.reset()?;
+
+    let status = OsCommand::new(&binary_path)
+        .args(std::env::args().skip(1))
+        .status();
+
+    match status {
+        Ok(s) => {
+            std::process::exit(s.code().unwrap_or(0));
+        }
+        Err(_) => {
+            let mut stdout = StandardStream::stdout(ColorChoice::Always);
+            stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))?;
+            writeln!(
+                &mut stdout,
+                "Installed forklaunch v{} at {:?}. Please re-run your command.",
+                required_version, binary_path
+            )?;
+            stdout.reset()?;
+            Ok(VersionCheckOutcome::ReexecNotSupported)
+        }
+    }
+}

--- a/cli/src/core/version_check.rs
+++ b/cli/src/core/version_check.rs
@@ -124,7 +124,6 @@ pub(crate) fn precheck_version(
     matches: &ArgMatches,
     subcommand: &str,
 ) -> Result<VersionCheckOutcome> {
-    // Skip for init application specifically
     if subcommand == "init" {
         if let Some((child, _)) = matches.subcommand() {
             if child == "application" {
@@ -133,8 +132,6 @@ pub(crate) fn precheck_version(
         }
     }
 
-    // Determine a sensible starting path for manifest discovery.
-    // Prefer an explicit path flag from the subcommand, else use CWD.
     let start_path: PathBuf = if let Some(p) = matches.get_one::<String>("base_path") {
         PathBuf::from(p)
     } else if let Some(p) = matches.get_one::<String>("path") {
@@ -143,7 +140,6 @@ pub(crate) fn precheck_version(
         current_dir().unwrap_or_else(|_| PathBuf::from("."))
     };
 
-    // Walk upwards from the provided path (or CWD) to find the nearest manifest.
     fn find_nearest_manifest_from(start: &Path) -> Option<PathBuf> {
         let mut base_path = start.canonicalize().ok()?;
         loop {
@@ -192,7 +188,6 @@ pub(crate) fn precheck_version(
         anyhow::bail!("Version mismatch. Aborting as per user choice.");
     }
 
-    // Informative messages before/after install
     let platform = platform_triple()?;
     stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
     writeln!(
@@ -213,7 +208,6 @@ pub(crate) fn precheck_version(
     )?;
     stdout.reset()?;
 
-    // Attempt to re-exec the command via the newly downloaded binary
     stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
     writeln!(
         &mut stdout,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,7 +59,6 @@ fn main() -> Result<()> {
         .subcommand(version.command())
         .get_matches();
 
-    // Centralized version precheck for all commands (soft-check semantics: if manifest, enforce; else proceed)
     if let Some((cmd, sub_matches)) = matches.subcommand() {
         crate::core::version_check::precheck_version(sub_matches, cmd)?;
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,6 +59,13 @@ fn main() -> Result<()> {
         .subcommand(version.command())
         .get_matches();
 
+    // Centralized version precheck for all commands except `version`.
+    if let Some((cmd, sub_matches)) = matches.subcommand() {
+        if cmd != "version" {
+            crate::core::version_check::precheck_version(sub_matches, cmd)?;
+        }
+    }
+
     let result = match matches.subcommand() {
         Some(("init", sub_matches)) => init.handler(sub_matches),
         Some(("change", sub_matches)) => change.handler(sub_matches),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,11 +59,9 @@ fn main() -> Result<()> {
         .subcommand(version.command())
         .get_matches();
 
-    // Centralized version precheck for all commands except `version`.
+    // Centralized version precheck for all commands (soft-check semantics: if manifest, enforce; else proceed)
     if let Some((cmd, sub_matches)) = matches.subcommand() {
-        if cmd != "version" {
-            crate::core::version_check::precheck_version(sub_matches, cmd)?;
-        }
+        crate::core::version_check::precheck_version(sub_matches, cmd)?;
     }
 
     let result = match matches.subcommand() {

--- a/cli/tests/precheck_version_match_allows_run.sh
+++ b/cli/tests/precheck_version_match_allows_run.sh
@@ -25,7 +25,11 @@ RUST_BACKTRACE=1 cargo run --release init application app \
 
 # 2) Force manifest cli_version to match the running cargo binary (0.0.0)
 MANIFEST="app/.forklaunch/manifest.toml"
-sed -E -i '' 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "0.0.0"/' "$MANIFEST"
+if [[ "$OSTYPE" == darwin* ]]; then
+  sed -E -i '' 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "0.0.0"/' "$MANIFEST"
+else
+  sed -E -i 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "0.0.0"/' "$MANIFEST"
+fi
 
 # 3) Run a command that triggers precheck; expect no prompt and success
 RUST_BACKTRACE=1 cargo run --release depcheck -p app

--- a/cli/tests/precheck_version_match_allows_run.sh
+++ b/cli/tests/precheck_version_match_allows_run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure a clean workspace for this test
+TEST_DIR="output/precheck-version-match"
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+
+# 1) Create a new application
+RUST_BACKTRACE=1 cargo run --release init application app \
+  -p . \
+  -d postgresql \
+  -f prettier \
+  -l eslint \
+  -v zod \
+  -F express \
+  -r node \
+  -t vitest \
+  -m billing-base \
+  -m iam-base \
+  -D "Test app" \
+  -A "Test Author" \
+  -L 'AGPL-3.0'
+
+# 2) Force manifest cli_version to match the running cargo binary (0.0.0)
+MANIFEST="app/.forklaunch/manifest.toml"
+sed -E -i '' 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "0.0.0"/' "$MANIFEST"
+
+# 3) Run a command that triggers precheck; expect no prompt and success
+RUST_BACKTRACE=1 cargo run --release depcheck -p app
+
+echo "OK: precheck version match allowed command to run"
+
+

--- a/cli/tests/precheck_version_mismatch_decline_fails.sh
+++ b/cli/tests/precheck_version_mismatch_decline_fails.sh
@@ -24,7 +24,11 @@ RUST_BACKTRACE=1 cargo run --release init application app \
 
 # 2) Force manifest cli_version to mismatch the running cargo binary (0.0.0)
 MANIFEST="app/.forklaunch/manifest.toml"
-sed -E -i '' 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "999.0.0"/' "$MANIFEST"
+if [[ "$OSTYPE" == darwin* ]]; then
+  sed -E -i '' 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "999.0.0"/' "$MANIFEST"
+else
+  sed -E -i 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "999.0.0"/' "$MANIFEST"
+fi
 
 # 3) Trigger a command and decline upgrade; expect non-zero exit
 set +e

--- a/cli/tests/precheck_version_mismatch_decline_fails.sh
+++ b/cli/tests/precheck_version_mismatch_decline_fails.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="output/precheck-version-mismatch-decline"
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+
+# 1) Create a new application
+RUST_BACKTRACE=1 cargo run --release init application app \
+  -p . \
+  -d postgresql \
+  -f prettier \
+  -l eslint \
+  -v zod \
+  -F express \
+  -r node \
+  -t vitest \
+  -m billing-base \
+  -m iam-base \
+  -D "Test app" \
+  -A "Test Author" \
+  -L 'AGPL-3.0'
+
+# 2) Force manifest cli_version to mismatch the running cargo binary (0.0.0)
+MANIFEST="app/.forklaunch/manifest.toml"
+sed -E -i '' 's/^cli_version[[:space:]]*=[[:space:]]*"[^"]*"/cli_version = "999.0.0"/' "$MANIFEST"
+
+# 3) Trigger a command and decline upgrade; expect non-zero exit
+set +e
+printf "n\n" | RUST_BACKTRACE=1 cargo run --release depcheck -p app >/dev/null 2>&1
+EXIT_CODE=$?
+set -e
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "Expected failure when declining version upgrade, but command succeeded" >&2
+  exit 1
+fi
+
+echo "OK: precheck version mismatch + decline failed as expected"
+
+


### PR DESCRIPTION
- Add core/version_check: locate nearest manifest, compare versions, prompt via prompt.rs, download required binary (reqwest), re-exec with new CLI or instruct user

- Add base_path::find_nearest_manifest_root_unbounded for non-interactive discovery

- Wire single precheck in main before dispatch; skip when no manifest; bypass for version; allow init application bootstrap

- Improve UX: print install start/complete and re-exec messages; validate HTTP status to avoid saving 404s

- Add dirs dependency; no changes to existing handlers or flags

Summary:

- Implements version enforcement per manifest with minimal, centralized changes and clear user prompts; preserves existing behavior for help/version and bootstrap flows.