### PR TITLE
FOR-11 cli std module placement path

### DIFF
--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/cli/src/init/application.rs
+++ b/cli/src/init/application.rs
@@ -771,12 +771,16 @@ impl CliCommand for ApplicationCommand {
                     .join(path_id.clone())
                     .to_string_lossy()
                     .to_string(),
-                output_path: path.name,
+                output_path: if path.variant.is_some() {
+                    format!("src/modules/{}", path.name)
+                } else {
+                    path.name.clone()
+                },
             }
         });
 
         template_dirs.extend(additional_projects_dirs.clone());
-        // println!("init:application:00: application_path: {:?}", application_path);
+        println!("init:application:00: template_dirs: {:?}", template_dirs);
         rendered_templates.extend(generate_with_template(
             Some(&application_path),
             &PathIO {
@@ -896,7 +900,8 @@ impl CliCommand for ApplicationCommand {
                     docker_compose_string,
                 )?);
             }
-
+            println!("init:application:01: application_path: {:?}", application_path);
+            println!("init:application:02: template_dir: {:?}", template_dir);
             rendered_templates.extend(generate_with_template(
                 Some(&application_path),
                 &template_dir,
@@ -921,6 +926,7 @@ impl CliCommand for ApplicationCommand {
                 };
 
             let service_base_path = Path::new(&application_path).join(&template_dir.output_path);
+            println!("init:application:03: service_base_path: {:?}", service_base_path);
             rendered_templates.push(generate_service_package_json(
                 &service_data,
                 &service_base_path,
@@ -1086,7 +1092,7 @@ impl CliCommand for ApplicationCommand {
 
         if additional_projects_names.contains(&"iam".to_string()) {
             rendered_templates.extend(
-                generate_iam_keys(&Path::new(&application_path)).with_context(|| ERROR_FAILED_TO_SETUP_IAM)?,
+                generate_iam_keys(&Path::new(&application_path).join("src/modules")).with_context(|| ERROR_FAILED_TO_SETUP_IAM)?,
             );
         }
 

--- a/cli/src/init/application.rs
+++ b/cli/src/init/application.rs
@@ -780,7 +780,7 @@ impl CliCommand for ApplicationCommand {
         });
 
         template_dirs.extend(additional_projects_dirs.clone());
-        println!("init:application:00: template_dirs: {:?}", template_dirs);
+        // println!("init:application:00: template_dirs: {:?}", template_dirs);
         rendered_templates.extend(generate_with_template(
             Some(&application_path),
             &PathIO {
@@ -900,8 +900,8 @@ impl CliCommand for ApplicationCommand {
                     docker_compose_string,
                 )?);
             }
-            println!("init:application:01: application_path: {:?}", application_path);
-            println!("init:application:02: template_dir: {:?}", template_dir);
+            // println!("init:application:01: application_path: {:?}", application_path);
+            // println!("init:application:02: template_dir: {:?}", template_dir);
             rendered_templates.extend(generate_with_template(
                 Some(&application_path),
                 &template_dir,
@@ -926,7 +926,7 @@ impl CliCommand for ApplicationCommand {
                 };
 
             let service_base_path = Path::new(&application_path).join(&template_dir.output_path);
-            println!("init:application:03: service_base_path: {:?}", service_base_path);
+            // println!("init:application:03: service_base_path: {:?}", service_base_path);
             rendered_templates.push(generate_service_package_json(
                 &service_data,
                 &service_base_path,

--- a/cli/src/init/module.rs
+++ b/cli/src/init/module.rs
@@ -80,6 +80,12 @@ impl CliCommand for ModuleCommand {
                     .help("Dry run the command")
                     .action(ArgAction::SetTrue),
             )
+            .arg(
+                Arg::new("module_folder")
+                    .short('f')
+                    .long("module-folder")
+                    .help("The folder to store the module in")
+            )
     }
 
     // pass token in from parent and perform get token above?
@@ -153,7 +159,9 @@ impl CliCommand for ModuleCommand {
 
         // Default output path should be src/modules/(module_name)
         let src_path = base_path.join("src");
-        let destination_path = if src_path.exists() && src_path.is_dir() {
+        let destination_path = if let Some(module_folder) = matches.get_one::<String>("module_folder") {
+            base_path.join(Path::new(&module_folder))
+        } else if src_path.exists() && src_path.is_dir() {
             src_path
                 .join("modules")
         } else {
@@ -183,6 +191,7 @@ impl CliCommand for ModuleCommand {
             base_path.join(Path::new(&temp_path)).to_path_buf()
         };
         println!("02: destination_path: {:?}", destination_path);
+
         let name = existing_manifest_data.app_name.clone();
 
         let mut service_data = ServiceManifestData {

--- a/cli/src/init/module.rs
+++ b/cli/src/init/module.rs
@@ -299,7 +299,7 @@ impl CliCommand for ModuleCommand {
             dryrun,
         )?);
         println!("06 destination_path: {:?}", destination_path);
-        println!("06 service_name: {:?}", get_service_module_name(&module));
+        println!("07 service_name: {:?}", get_service_module_name(&module));
         rendered_templates.push(generate_service_package_json(
             &service_data,
             &destination_path.join(get_service_module_name(&module)),
@@ -327,11 +327,12 @@ impl CliCommand for ModuleCommand {
         }
 
         write_rendered_templates(&rendered_templates, dryrun, &mut stdout)?;
-
+        println!("module:08: base_path: {:?}", base_path);
+        println!("module:09: destination_path: {:?}", destination_path);
         if !dryrun {
             generate_symlinks(
                 Some(base_path),
-                &base_path.join(get_service_module_name(&module)),
+                &destination_path.join(get_service_module_name(&module)),
                 &mut service_data,
                 dryrun,
             )?;

--- a/cli/src/init/module.rs
+++ b/cli/src/init/module.rs
@@ -102,12 +102,12 @@ impl CliCommand for ModuleCommand {
             &BasePathType::Init,
         )?;
         let base_path = Path::new(&base_path_input);
-        println!("00: base_path: {:?}", base_path);
+        // println!("00: base_path: {:?}", base_path);
 
         let config_path = Path::new(&base_path)
             .join(".forklaunch")
             .join("manifest.toml");
-        println!("01: config_path: {:?}", config_path);
+        // println!("01: config_path: {:?}", config_path);
         let existing_manifest_data = toml::from_str::<ApplicationManifestData>(
             &read_to_string(&config_path).with_context(|| ERROR_FAILED_TO_READ_MANIFEST)?,
         )
@@ -190,7 +190,7 @@ impl CliCommand for ModuleCommand {
             )?;
             base_path.join(Path::new(&temp_path)).to_path_buf()
         };
-        println!("02: destination_path: {:?}", destination_path);
+        // println!("02: destination_path: {:?}", destination_path);
 
         let name = existing_manifest_data.app_name.clone();
 
@@ -282,22 +282,22 @@ impl CliCommand for ModuleCommand {
                 .to_string(),
             module_id: Some(module.clone()),
         };
-        println!("03: template_dir: {:?}", template_dir);
+        // println!("03: template_dir: {:?}", template_dir);
 
         let mut rendered_templates = vec![];
-        println!("04: config_path: {:?}", config_path);
+        // println!("04: config_path: {:?}", config_path);
         rendered_templates.push(RenderedTemplate {
             path: config_path.clone(),
             content: manifest_data,
             context: Some(ERROR_FAILED_TO_WRITE_MANIFEST.to_string()),
         });
-        println!("docker-compose.yaml: {:?}", base_path.join("docker-compose.yaml"));
+        // println!("docker-compose.yaml: {:?}", base_path.join("docker-compose.yaml"));
         rendered_templates.push(RenderedTemplate {
             path: base_path.join("docker-compose.yaml"),
             content: add_service_definition_to_docker_compose(&service_data, base_path, None)?,
             context: Some(ERROR_FAILED_TO_WRITE_DOCKER_COMPOSE.to_string()),
         });
-        println!("05: template_dir: {:?}", template_dir);
+        // println!("05: template_dir: {:?}", template_dir);
         rendered_templates.extend(generate_with_template(
             None,
             &template_dir,
@@ -307,8 +307,8 @@ impl CliCommand for ModuleCommand {
             &vec![],
             dryrun,
         )?);
-        println!("06 destination_path: {:?}", destination_path);
-        println!("07 service_name: {:?}", get_service_module_name(&module));
+        // println!("06 destination_path: {:?}", destination_path);
+        // println!("07 service_name: {:?}", get_service_module_name(&module));
         rendered_templates.push(generate_service_package_json(
             &service_data,
             &destination_path.join(get_service_module_name(&module)),
@@ -336,8 +336,8 @@ impl CliCommand for ModuleCommand {
         }
 
         write_rendered_templates(&rendered_templates, dryrun, &mut stdout)?;
-        println!("module:08: base_path: {:?}", base_path);
-        println!("module:09: destination_path: {:?}", destination_path);
+        // println!("module:08: base_path: {:?}", base_path);
+        // println!("module:09: destination_path: {:?}", destination_path);
         if !dryrun {
             generate_symlinks(
                 Some(base_path),

--- a/cli/src/init/service.rs
+++ b/cli/src/init/service.rs
@@ -103,7 +103,8 @@ fn generate_basic_service(
     let ignore_files = vec![];
     let ignore_dirs = vec![];
     let preserve_files = vec![];
-
+    println!("service:00: template_dir: {:?}", template_dir);
+    println!("service:00: base_path: {:?}", base_path);
     let mut rendered_templates = generate_with_template(
         None,
         &template_dir,
@@ -146,7 +147,8 @@ fn generate_basic_service(
             context: Some(ERROR_FAILED_TO_UPDATE_DOCKERFILE.to_string()),
         });
     }
-
+    println!("service:01: template_dir: {:?}", template_dir);
+    println!("service:01: base_path: {:?}", base_path);
     add_project_to_universal_sdk(
         &mut rendered_templates,
         base_path,
@@ -157,6 +159,8 @@ fn generate_basic_service(
     write_rendered_templates(&rendered_templates, dryrun, stdout)
         .with_context(|| ERROR_FAILED_TO_WRITE_SERVICE_FILES)?;
 
+    println!("service:02: template_dir: {:?}", template_dir);
+    println!("service:02: base_path: {:?}", base_path);
     generate_symlinks(
         Some(base_path),
         &Path::new(&template_dir.output_path),

--- a/cli/tests/change_application.sh
+++ b/cli/tests/change_application.sh
@@ -7,14 +7,14 @@ cd output/change-application
 
 RUST_BACKTRACE=1 cargo run --release init application change-application-test-node-application -p . -d postgresql -f prettier -l eslint -v zod -F hyper-express -r node -t vitest -m billing-base -m iam-base -D "Test service" -A "Rohin Bhargava" -L 'AGPL-3.0'
 
-cd change-application-test-node-application
+# cd change-application-test-node-application
 
 pnpm install
 pnpm build
 
 cd ..
 
-RUST_BACKTRACE=1 cargo run --release change application -p change-application-test-node-application -N change-application-test-bun-application -f biome -l oxlint -v typebox -F express -r bun -t jest -D "Test service 2" -A "Rohin Bhargava A" -L "MIT" -c
+RUST_BACKTRACE=1 cargo run --release change application -p change-application -N change-application-test-bun-application -f biome -l oxlint -v typebox -F express -r bun -t jest -D "Test service 2" -A "Rohin Bhargava A" -L "MIT" -c
 
 cd change-application-test-bun-application
 

--- a/cli/tests/init_module.sh
+++ b/cli/tests/init_module.sh
@@ -6,8 +6,8 @@ mkdir -p output/init-module
 cd output/init-module
 
 RUST_BACKTRACE=1 cargo run --release init application service-test-node-application -p . -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -D "Test service" -A "Rohin Bhargava" -L 'AGPL-3.0'
-RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-node-application
-RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-node-application
+RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-node-application -f src/modules
+RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-node-application -f src/modules
 
 cd service-test-node-application
 
@@ -17,8 +17,8 @@ pnpm build
 cd ..
 
 RUST_BACKTRACE=1 cargo run --release init application service-test-bun-application -p . -d postgresql -f biome -l oxlint -v zod -F express -r bun -t vitest -D "Test service" -A "Rohin Bhargava" -L "MIT"
-RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-bun-application
-RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-bun-application
+RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-bun-application -f src/modules
+RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-bun-application -f src/modules
 
 cd service-test-bun-application
 

--- a/cli/tests/init_module_src_path.sh
+++ b/cli/tests/init_module_src_path.sh
@@ -1,0 +1,29 @@
+if [ -d "output/init-module" ]; then
+    rm -rf output/init-module
+fi
+
+mkdir -p output/init-module
+cd output/init-module
+
+RUST_BACKTRACE=1 cargo run --release init application service-test-node-application -p . -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -D "Test service" -A "Rohin Bhargava" -L 'AGPL-3.0'
+mkdir -p service-test-node-application/src
+RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-node-application
+RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-node-application
+
+cd service-test-node-application
+
+pnpm install
+pnpm build
+
+cd ..
+
+RUST_BACKTRACE=1 cargo run --release init application service-test-bun-application -p . -d postgresql -f biome -l oxlint -v zod -F express -r bun -t vitest -D "Test service" -A "Rohin Bhargava" -L "MIT"
+RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-bun-application
+RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-bun-application
+
+cd service-test-bun-application
+
+bun install
+bun run build
+
+cd ..

--- a/cli/tests/init_module_src_path.sh
+++ b/cli/tests/init_module_src_path.sh
@@ -5,25 +5,25 @@ fi
 mkdir -p output/init-module
 cd output/init-module
 
-RUST_BACKTRACE=1 cargo run --release init application service-test-node-application -p . -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -D "Test service" -A "Rohin Bhargava" -L 'AGPL-3.0'
-mkdir -p service-test-node-application/src
-RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-node-application
-RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-node-application
+RUST_BACKTRACE=1 cargo run --release init application module-test-src-path -p ./module-test-src-path -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -D "Test service" -A "ForkLaunch" -L 'AGPL-3.0'
+mkdir -p module-test-src-path/src
+RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p ./module-test-src-path
+RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p ./module-test-src-path
 
-cd service-test-node-application
+cd module-test-src-path
 
 pnpm install
 pnpm build
 
 cd ..
 
-RUST_BACKTRACE=1 cargo run --release init application service-test-bun-application -p . -d postgresql -f biome -l oxlint -v zod -F express -r bun -t vitest -D "Test service" -A "Rohin Bhargava" -L "MIT"
-RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p service-test-bun-application
-RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p service-test-bun-application
+RUST_BACKTRACE=1 cargo run --release init application module-test-no-src-path -p ./module-test-no-src-path -d postgresql -f biome -l oxlint -v zod -F express -r node -t vitest -D "Test service" -A "ForkLaunch" -L "MIT"
+RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p module-test-no-src-path -f modules
+RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p module-test-no-src-path -f modules
 
-cd service-test-bun-application
+cd module-test-no-src-path
 
-bun install
-bun run build
+pnpm install
+pnpm build
 
 cd ..

--- a/cli/tests/init_module_src_path.sh
+++ b/cli/tests/init_module_src_path.sh
@@ -5,6 +5,7 @@ fi
 mkdir -p output/init-module
 cd output/init-module
 
+# Test for specific path for modules using -f flag (src path)
 RUST_BACKTRACE=1 cargo run --release init application module-test-src-path -p ./module-test-src-path -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -D "Test service" -A "ForkLaunch" -L 'AGPL-3.0'
 mkdir -p module-test-src-path/src
 RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p ./module-test-src-path
@@ -16,7 +17,7 @@ pnpm install
 pnpm build
 
 cd ..
-
+# Test for specific path for modules using -f flag (no src path)
 RUST_BACKTRACE=1 cargo run --release init application module-test-no-src-path -p ./module-test-no-src-path -d postgresql -f biome -l oxlint -v zod -F express -r node -t vitest -D "Test service" -A "ForkLaunch" -L "MIT"
 RUST_BACKTRACE=1 cargo run --release init module -m iam-base -d postgresql -p module-test-no-src-path -f modules
 RUST_BACKTRACE=1 cargo run --release init module -m billing-base -d postgresql -p module-test-no-src-path -f modules


### PR DESCRIPTION
Standardized location of modules (iam, billing) to be stored in src/modules during init application or init module

Changes

- Users are prompted if no src file is found
- modules destination folder flag added to ModuleCommand for use in testing