### PR TITLE
fix: fixed the universal sdk path resolve issue.

### DIFF
--- a/framework/universal-sdk/src/universalSdk.ts
+++ b/framework/universal-sdk/src/universalSdk.ts
@@ -183,7 +183,9 @@ export class UniversalSdk {
 
     if (params) {
       for (const key in params) {
-        url = url.replace(`:${key}`, encodeURIComponent(params[key] as string));
+        const paramValue = encodeURIComponent(params[key] as string);
+        url = url.replace(`:${key}`, paramValue);
+        url = url.replace(`{${key}}`, paramValue);
       }
     }
 


### PR DESCRIPTION
Bug Fix Summary - Universal SDK Path Parameter Substitution

✅ Problem Identified and Fixed

Root Cause: The Universal SDK had a path parameter substitution bug where SDK method calls failed to substitute OpenAPI-style parameters `({id})` while fetch calls worked correctly with Express-style parameters `(:id)`.

Technical Issue:
Fetch calls: Used paths directly from users (e.g., `/organization/:id`) → parameter substitution worked ✅
SDK calls: Retrieved paths from OpenAPI spec (e.g., `/organization/{id}`) → parameter substitution failed ❌

Fix:
`url = url.replace(`{${key}}`, paramValue);`