### PR TITLE
fix: fixed the collection mapping error.

### DIFF
--- a/blueprint/iam-base/domain/mappers/organization.mappers.ts
+++ b/blueprint/iam-base/domain/mappers/organization.mappers.ts
@@ -46,14 +46,16 @@ export class OrganizationMapper extends ResponseMapper<
     this.dto = {
       ...(await entity.read()),
       users: await Promise.all(
-        entity.users.map(async (user) =>
-          (
-            await UserMapper.fromEntity(
-              this.schemaValidator as SchemaValidator,
-              user
-            )
-          ).toDto()
-        )
+        entity.users
+          .getItems()
+          .map(async (user) =>
+            (
+              await UserMapper.fromEntity(
+                this.schemaValidator as SchemaValidator,
+                user
+              )
+            ).toDto()
+          )
       )
     };
     return this;

--- a/blueprint/iam-base/domain/mappers/role.mappers.ts
+++ b/blueprint/iam-base/domain/mappers/role.mappers.ts
@@ -39,14 +39,16 @@ export class RoleMapper extends ResponseMapper<Role, SchemaValidator> {
     this.dto = {
       ...(await entity.read()),
       permissions: await Promise.all(
-        entity.permissions.map(async (permission) =>
-          (
-            await PermissionMapper.fromEntity(
-              this.schemaValidator as SchemaValidator,
-              permission
-            )
-          ).toDto()
-        )
+        entity.permissions
+          .getItems()
+          .map(async (permission) =>
+            (
+              await PermissionMapper.fromEntity(
+                this.schemaValidator as SchemaValidator,
+                permission
+              )
+            ).toDto()
+          )
       )
     };
     return this;

--- a/blueprint/iam-base/domain/mappers/user.mappers.ts
+++ b/blueprint/iam-base/domain/mappers/user.mappers.ts
@@ -43,14 +43,16 @@ export class UserMapper extends ResponseMapper<User, SchemaValidator> {
     this.dto = {
       ...(await entity.read()),
       roles: await Promise.all(
-        entity.roles.map(async (role) =>
-          (
-            await RoleMapper.fromEntity(
-              this.schemaValidator as SchemaValidator,
-              role
-            )
-          ).toDto()
-        )
+        entity.roles
+          .getItems()
+          .map(async (role) =>
+            (
+              await RoleMapper.fromEntity(
+                this.schemaValidator as SchemaValidator,
+                role
+              )
+            ).toDto()
+          )
       )
     };
 

--- a/blueprint/iam-better-auth/domain/mappers/organization.mappers.ts
+++ b/blueprint/iam-better-auth/domain/mappers/organization.mappers.ts
@@ -46,14 +46,16 @@ export class OrganizationMapper extends ResponseMapper<
     this.dto = {
       ...(await entity.read()),
       users: await Promise.all(
-        entity.users.map(async (user) =>
-          (
-            await UserMapper.fromEntity(
-              this.schemaValidator as SchemaValidator,
-              user
-            )
-          ).toDto()
-        )
+        entity.users
+          .getItems()
+          .map(async (user) =>
+            (
+              await UserMapper.fromEntity(
+                this.schemaValidator as SchemaValidator,
+                user
+              )
+            ).toDto()
+          )
       )
     };
     return this;

--- a/blueprint/iam-better-auth/domain/mappers/user.mappers.ts
+++ b/blueprint/iam-better-auth/domain/mappers/user.mappers.ts
@@ -47,14 +47,16 @@ export class UserMapper extends ResponseMapper<User, SchemaValidator> {
     this.dto = {
       ...(await entity.read()),
       roles: await Promise.all(
-        entity.roles.map(async (role) =>
-          (
-            await RoleMapper.fromEntity(
-              this.schemaValidator as SchemaValidator,
-              role
-            )
-          ).toDto()
-        )
+        entity.roles
+          .getItems()
+          .map(async (role) =>
+            (
+              await RoleMapper.fromEntity(
+                this.schemaValidator as SchemaValidator,
+                role
+              )
+            ).toDto()
+          )
       )
     };
 

--- a/blueprint/implementations/iam/base/services/organization.service.ts
+++ b/blueprint/implementations/iam/base/services/organization.service.ts
@@ -143,7 +143,10 @@ export class BaseOrganizationService<
 
     const organization = await (em ?? this.em).findOneOrFail(
       'Organization',
-      idDto
+      idDto,
+      {
+        populate: ['id', '*']
+      }
     );
 
     return this._mappers.OrganizationMapper.serializeEntityToDto(


### PR DESCRIPTION
Fix MikroORM Collection access in entity mappers

Fixed mapping errors by using .getItems().map() instead of direct .map() on MikroORM Collections. Collections are wrapper objects, not arrays, so direct array methods fail. This resolves 500 errors when serializing entities with populated relationships in Organization, User, and Role mappers.