### PR TITLE
fix: Small CLI fixes pre 0.3.0 release

### DIFF
--- a/cli/src/change/core/change_database.rs
+++ b/cli/src/change/core/change_database.rs
@@ -13,7 +13,7 @@ use crate::{
         manifest::ProjectEntry,
         package_json::{
             application_package_json::ApplicationPackageJson,
-            package_json_constants::MIKRO_ORM_DATABASE_VERSION,
+            package_json_constants::{MIKRO_ORM_DATABASE_VERSION, PROJECT_SEED_SCRIPT},
             project_package_json::ProjectPackageJson,
         },
         removal_template::{RemovalTemplate, RemovalTemplateType},
@@ -216,4 +216,14 @@ pub(crate) fn change_database_postinstall_script(
         .as_mut()
         .unwrap()
         .postinstall = get_postinstall_script(database);
+}
+
+pub(crate) fn change_database_seed_script(
+    project_package_json: &mut ProjectPackageJson,
+    database: &Database,
+) {
+    project_package_json.scripts.as_mut().unwrap().seed = match database {
+        Database::MongoDB => None,
+        _ => Some(PROJECT_SEED_SCRIPT.to_string()),
+    };
 }

--- a/cli/src/change/service.rs
+++ b/cli/src/change/service.rs
@@ -17,6 +17,7 @@ use super::core::{
 };
 use crate::{
     CliCommand,
+    change::core::change_database::change_database_seed_script,
     constants::{
         Database, ERROR_FAILED_TO_PARSE_MANIFEST, ERROR_FAILED_TO_READ_DOCKER_COMPOSE,
         ERROR_FAILED_TO_READ_MANIFEST, ERROR_FAILED_TO_READ_PACKAGE_JSON, Infrastructure,
@@ -210,6 +211,7 @@ fn change_database(
     );
 
     change_database_postinstall_script(application_package_json, database);
+    change_database_seed_script(project_package_json, database);
 
     let removal_template = change_database_base_entity(
         base_path,

--- a/cli/src/change/worker.rs
+++ b/cli/src/change/worker.rs
@@ -18,6 +18,7 @@ use super::core::{
 };
 use crate::{
     CliCommand,
+    change::core::change_database::change_database_seed_script,
     constants::{
         Database, ERROR_FAILED_TO_PARSE_MANIFEST, ERROR_FAILED_TO_READ_DOCKER_COMPOSE,
         ERROR_FAILED_TO_READ_MANIFEST, ERROR_FAILED_TO_READ_PACKAGE_JSON, WorkerType,
@@ -280,6 +281,7 @@ fn change_type(
             );
 
             change_database_postinstall_script(application_package_json, &db);
+            change_database_seed_script(project_package_json, &db);
 
             rendered_templates_cache.insert(
                 base_path.join("mikro-orm.config.ts").to_string_lossy(),

--- a/cli/src/core/docker.rs
+++ b/cli/src/core/docker.rs
@@ -1383,6 +1383,8 @@ pub(crate) fn add_service_definition_to_docker_compose(
             manifest_data.app_name, manifest_data.service_name
         ),
         format!("/{}/core/node_modules", manifest_data.app_name),
+        format!("/{}/monitoring/node_modules", manifest_data.app_name),
+        format!("/{}/universal-sdk/node_modules", manifest_data.app_name),
         format!("/{}/node_modules", manifest_data.app_name),
     ];
 

--- a/cli/src/core/package_json/package_json_constants.rs
+++ b/cli/src/core/package_json/package_json_constants.rs
@@ -107,7 +107,7 @@ pub(crate) fn application_docs_script(runtime: &Runtime) -> String {
 fn get_package_manager(runtime: &Runtime) -> String {
     let package_manager = match runtime {
         Runtime::Bun => "bun --filter='*'",
-        Runtime::Node => "pnpm -r",
+        Runtime::Node => "pnpm -r --no-bail",
     };
 
     String::from(package_manager)
@@ -204,7 +204,9 @@ pub(crate) fn application_test_script<'a>(
 
 pub(crate) fn application_up_packages_script(runtime: &Runtime) -> String {
     String::from(match runtime {
-        Runtime::Bun => "bun update --latest && bun --filter='*' update --latest",
+        Runtime::Bun => {
+            "bun update --latest && bun --filter='*' run update --latest && bun install"
+        }
         Runtime::Node => "pnpm -r --no-bail update --latest",
     })
 }

--- a/cli/src/init/service.rs
+++ b/cli/src/init/service.rs
@@ -303,7 +303,11 @@ pub(crate) fn generate_service_package_json(
                 migrate_down: Some(project_migrate_script("down")),
                 migrate_init: Some(project_migrate_script("init")),
                 migrate_up: Some(project_migrate_script("up")),
-                seed: Some(PROJECT_SEED_SCRIPT.to_string()),
+                seed: if !manifest_data.is_mongo {
+                    Some(PROJECT_SEED_SCRIPT.to_string())
+                } else {
+                    None
+                },
                 start: Some(project_start_server_script(
                     &manifest_data.runtime.parse()?,
                     manifest_data.database.parse::<Database>().ok(),

--- a/cli/src/init/worker.rs
+++ b/cli/src/init/worker.rs
@@ -350,7 +350,7 @@ pub(crate) fn generate_worker_package_json(
                 } else {
                     None
                 },
-                seed: if manifest_data.is_database_enabled {
+                seed: if manifest_data.is_database_enabled && !manifest_data.is_mongo {
                     Some(PROJECT_SEED_SCRIPT.to_string())
                 } else {
                     None


### PR DESCRIPTION
Fixes more small bugs:
- Seed script should not exist in mongo projects
- adds volumes from standard projects in docker compose projects
- adds no bail for migration scripts
- fixes bun package update script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Database-aware seeding: seeding is disabled for MongoDB and enabled for other databases across init and change flows.

* Chores
  * Updated package manager commands: pnpm now continues on errors (--no-bail); bun update flow now runs “bun run update” and a follow-up install for reliability.
  * Added Docker Compose volume mounts for monitoring and universal SDK node_modules to improve local development performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->