### PR TITLE
fix: bump OpenAPI export timeout from 30s to 60s

### DIFF
--- a/cli/src/core/openapi_export.rs
+++ b/cli/src/core/openapi_export.rs
@@ -200,7 +200,7 @@ pub(crate) fn export_service_openapi(
         .spawn()
         .with_context(|| format!("Failed to spawn {} command", resolved_bin))?;
 
-    let timeout = Duration::from_secs(30);
+    let timeout = Duration::from_secs(45);
     let start = Instant::now();
     loop {
         match child.try_wait() {

--- a/cli/src/core/openapi_export.rs
+++ b/cli/src/core/openapi_export.rs
@@ -200,7 +200,7 @@ pub(crate) fn export_service_openapi(
         .spawn()
         .with_context(|| format!("Failed to spawn {} command", resolved_bin))?;
 
-    let timeout = Duration::from_secs(45);
+    let timeout = Duration::from_secs(60);
     let start = Instant::now();
     loop {
         match child.try_wait() {


### PR DESCRIPTION
Raises the per-service subprocess timeout in forklaunch openapi export from 30s to 60s to stop slower services from intermittently timing out.