### PR TITLE
cli: wire forklaunch-platform autodeploy

### DIFF
--- a/cli/src/core/http_client.rs
+++ b/cli/src/core/http_client.rs
@@ -134,10 +134,24 @@ fn make_hmac_request(
     body: Option<Value>,
 ) -> Result<Response> {
     let path = extract_url_path(url)?;
+    make_hmac_request_with_sign_path(secret_key, method, url, &path, body)
+}
+
+/// Same as `make_hmac_request` but lets the caller specify the path that gets
+/// signed. Use when the backend's HMAC verifier uses a router-relative path
+/// that differs from the full URL path (e.g. forklaunch's `@forklaunch/core`
+/// uses `req.path`, which strips the router base mount).
+fn make_hmac_request_with_sign_path(
+    secret_key: &str,
+    method: Method,
+    url: &str,
+    sign_path: &str,
+    body: Option<Value>,
+) -> Result<Response> {
     let auth_header = generate_hmac_auth_header(
         secret_key,
         method.as_str(),
-        &path,
+        sign_path,
         body.as_ref(),
     )?;
 
@@ -161,6 +175,26 @@ pub fn post_with_auth(auth_mode: &AuthMode, url: &str, body: Value) -> Result<Re
         AuthMode::Hmac { secret_key } => {
             make_hmac_request(secret_key, Method::POST, url, Some(body))
         }
+    }
+}
+
+/// POST with auth mode dispatch, where the HMAC sign path is supplied by the
+/// caller (use when the backend's `req.path` differs from the URL path).
+pub fn post_with_auth_and_sign_path(
+    auth_mode: &AuthMode,
+    url: &str,
+    sign_path: &str,
+    body: Value,
+) -> Result<Response> {
+    match auth_mode {
+        AuthMode::Jwt => post(url, body),
+        AuthMode::Hmac { secret_key } => make_hmac_request_with_sign_path(
+            secret_key,
+            Method::POST,
+            url,
+            sign_path,
+            Some(body),
+        ),
     }
 }
 

--- a/cli/src/release/create.rs
+++ b/cli/src/release/create.rs
@@ -171,6 +171,14 @@ struct CreateReleaseRequest {
     manifest: ReleaseManifest,
     #[serde(rename = "releasedBy", skip_serializing_if = "Option::is_none")]
     released_by: Option<String>,
+    /// Pin the autodeploy fan-out to a specific environment. Honored by
+    /// `FORKLAUNCH_TARGET_ENVIRONMENT` env var (set by the worker when the
+    /// webhook already matched the push to an env via the branch matrix).
+    #[serde(
+        rename = "targetEnvironment",
+        skip_serializing_if = "Option::is_none"
+    )]
+    target_environment: Option<String>,
 }
 
 #[derive(Debug)]
@@ -382,16 +390,31 @@ impl CliCommand for CreateCommand {
         if local_mode {
             log_info!(stdout, "Using local mode - packaging code directly");
         } else if is_git_repo() {
-            // Warn user and checkout main branch with latest changes
-            log_warn!(
+            // Git mode releases whatever commit is checked out, but the working
+            // tree must be clean — uncommitted changes would not be reproducible
+            // from the released commit alone.
+            let status_output = ProcessCommand::new("git")
+                .args(&["status", "--porcelain"])
+                .output()
+                .with_context(|| "Failed to check git status")?;
+            if !status_output.status.success() {
+                bail!("Failed to check git status");
+            }
+            let dirty = !status_output.stdout.is_empty();
+            if dirty {
+                let dirty_text = String::from_utf8_lossy(&status_output.stdout);
+                bail!(
+                    "Working tree has uncommitted changes; commit, stash, or discard them before releasing from git:\n{}",
+                    dirty_text.trim_end()
+                );
+            }
+
+            let current_branch = get_git_branch().unwrap_or_else(|_| "HEAD".to_string());
+            log_info!(
                 stdout,
-                "Releasing from git will checkout the main branch and pull latest changes."
+                "Releasing from current branch '{}' (no checkout, no pull)",
+                current_branch
             );
-            log_warn!(
-                stdout,
-                "Please save any uncommitted work before proceeding."
-            );
-            writeln!(stdout)?;
 
             if !auto_yes {
                 let confirmed = Confirm::with_theme(&ColorfulTheme::default())
@@ -403,35 +426,6 @@ impl CliCommand for CreateCommand {
                     bail!("Release cancelled by user");
                 }
             }
-
-            log_header!(stdout, Color::Cyan, "Checking out main branch...");
-            writeln!(stdout)?;
-
-            let checkout_status = ProcessCommand::new("git")
-                .args(&["checkout", "main"])
-                .status()
-                .with_context(|| "Failed to checkout main branch")?;
-
-            if !checkout_status.success() {
-                bail!("Failed to checkout main branch");
-            }
-
-            log_ok!(stdout, "Checked out main branch");
-
-            log_header!(stdout, Color::Cyan, "Pulling latest changes...");
-            writeln!(stdout)?;
-
-            let pull_status = ProcessCommand::new("git")
-                .args(&["pull"])
-                .status()
-                .with_context(|| "Failed to pull latest changes")?;
-
-            if !pull_status.success() {
-                bail!("Failed to pull latest changes");
-            }
-
-            log_ok!(stdout, "Pulled latest changes");
-            writeln!(stdout)?;
         }
 
         log_header!(stdout, Color::Cyan, "Creating release {}...", version);
@@ -1186,17 +1180,28 @@ fn upload_release(
         application_id: application_id.to_string(),
         manifest,
         released_by: None, // TODO: Get from token
+        target_environment: std::env::var("FORKLAUNCH_TARGET_ENVIRONMENT")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
     };
 
-    let url = if auth_mode.is_hmac() {
-        format!("{}/releases/internal", get_platform_management_api_url())
+    let (url, sign_path) = if auth_mode.is_hmac() {
+        (
+            format!("{}/releases/internal", get_platform_management_api_url()),
+            "/internal",
+        )
     } else {
-        format!("{}/releases", get_platform_management_api_url())
+        (format!("{}/releases", get_platform_management_api_url()), "/")
     };
 
-    let response =
-        http_client::post_with_auth(auth_mode, &url, serde_json::to_value(&request_body)?)
-            .with_context(|| "Failed to create release")?;
+    let response = http_client::post_with_auth_and_sign_path(
+        auth_mode,
+        &url,
+        sign_path,
+        serde_json::to_value(&request_body)?,
+    )
+    .with_context(|| "Failed to create release")?;
 
     let status = response.status();
     let response_body = response.text().unwrap_or_else(|_| "{}".to_string());
@@ -2322,6 +2327,12 @@ fn is_platform_managed_var(var_name: &str) -> bool {
         // Pulumi-generated: derived from other vars at deploy time
         "JWKS_PUBLIC_KEY_URL",
         "BETTER_AUTH_BASE_URL",
+        // Pulumi-generated: derived from the iam service URL (auth.ts wires
+        // BETTER_AUTH_URL = the deployed iam FQDN).
+        "BETTER_AUTH_URL",
+        // Pulumi-generated: derived from the application's public client URL
+        // (CORS_ORIGINS = the deployed frontend origin(s)).
+        "CORS_ORIGINS",
         // Pulumi-generated: IAM-specific database
         "IAM_DB_NAME",
         // Pulumi-generated: database

--- a/cli/src/release/git.rs
+++ b/cli/src/release/git.rs
@@ -24,29 +24,60 @@ pub(crate) fn get_git_commit() -> Result<String> {
     Ok(commit)
 }
 
-/// Get the current git branch name
+/// Get the current git branch name.
+///
+/// Honors `FORKLAUNCH_GIT_BRANCH` env var first — useful when HEAD is
+/// detached (e.g. the autorelease worker checks out a specific commit)
+/// and `git` can't infer the branch on its own.
 pub(crate) fn get_git_branch() -> Result<String> {
+    if let Ok(b) = std::env::var("FORKLAUNCH_GIT_BRANCH") {
+        let trimmed = b.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
     let output = Command::new("git")
         .args(&["branch", "--show-current"])
         .output()
         .with_context(|| "Failed to execute git command")?;
 
-    if !output.status.success() {
-        let output = Command::new("git")
-            .args(&["rev-parse", "--abbrev-ref", "HEAD"])
-            .output()
-            .with_context(|| "Failed to get git branch")?;
-
-        if !output.status.success() {
-            return Ok("unknown".to_string());
-        }
-
+    if output.status.success() {
         let branch = String::from_utf8(output.stdout)
             .with_context(|| "Invalid UTF-8 in git output")?
             .trim()
             .to_string();
+        if !branch.is_empty() {
+            return Ok(branch);
+        }
+        // Detached HEAD — try to find a branch pointing at HEAD.
+        if let Ok(out) = Command::new("git")
+            .args(&[
+                "for-each-ref",
+                "--format=%(refname:short)",
+                "--points-at",
+                "HEAD",
+                "refs/heads/",
+            ])
+            .output()
+        {
+            let candidate = String::from_utf8_lossy(&out.stdout);
+            if let Some(first) = candidate.lines().next() {
+                let trimmed = first.trim();
+                if !trimmed.is_empty() {
+                    return Ok(trimmed.to_string());
+                }
+            }
+        }
+    }
 
-        return Ok(branch);
+    let output = Command::new("git")
+        .args(&["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .with_context(|| "Failed to get git branch")?;
+
+    if !output.status.success() {
+        return Ok("unknown".to_string());
     }
 
     let branch = String::from_utf8(output.stdout)

--- a/cli/src/release/s3_upload.rs
+++ b/cli/src/release/s3_upload.rs
@@ -91,15 +91,29 @@ pub(crate) fn get_presigned_upload_url(
 ) -> Result<UploadUrlResponse> {
     use crate::core::http_client;
 
-    let url = format!("{}/releases/upload-url", get_platform_management_api_url());
+    let (url, sign_path) = if auth_mode.is_hmac() {
+        (
+            format!(
+                "{}/releases/internal/upload-url",
+                get_platform_management_api_url()
+            ),
+            "/internal/upload-url",
+        )
+    } else {
+        (
+            format!("{}/releases/upload-url", get_platform_management_api_url()),
+            "/upload-url",
+        )
+    };
 
     let request_body = serde_json::json!({
         "applicationId": application_id,
         "version": version
     });
 
-    let response = http_client::post_with_auth(auth_mode, &url, request_body)
-        .with_context(|| "Failed to request upload URL from platform")?;
+    let response =
+        http_client::post_with_auth_and_sign_path(auth_mode, &url, sign_path, request_body)
+            .with_context(|| "Failed to request upload URL from platform")?;
 
     let status = response.status();
     if !status.is_success() {
@@ -172,10 +186,23 @@ pub(crate) fn get_openapi_upload_urls(
 ) -> Result<HashMap<String, OpenApiUploadUrlEntry>> {
     use crate::core::http_client;
 
-    let url = format!(
-        "{}/releases/openapi-upload-urls",
-        get_platform_management_api_url()
-    );
+    let (url, sign_path) = if auth_mode.is_hmac() {
+        (
+            format!(
+                "{}/releases/internal/openapi-upload-urls",
+                get_platform_management_api_url()
+            ),
+            "/internal/openapi-upload-urls",
+        )
+    } else {
+        (
+            format!(
+                "{}/releases/openapi-upload-urls",
+                get_platform_management_api_url()
+            ),
+            "/openapi-upload-urls",
+        )
+    };
 
     let request_body = serde_json::json!({
         "applicationId": application_id,
@@ -183,8 +210,9 @@ pub(crate) fn get_openapi_upload_urls(
         "serviceNames": service_names
     });
 
-    let response = http_client::post_with_auth(auth_mode, &url, request_body)
-        .with_context(|| "Failed to request OpenAPI upload URLs from platform")?;
+    let response =
+        http_client::post_with_auth_and_sign_path(auth_mode, &url, sign_path, request_body)
+            .with_context(|| "Failed to request OpenAPI upload URLs from platform")?;
 
     let status = response.status();
     if !status.is_success() {


### PR DESCRIPTION
CLI changes needed by the platform's autorelease+autodeploy pipeline:

- HMAC sign-path override on /releases/internal endpoints (backend uses router-relative `req.path`; CLI was signing the full URL path → 403).
- Route to /releases/internal/upload-url and /releases/internal/openapi-upload-urls when in HMAC mode so the worker can fetch presigned URLs without user JWT.
- New `target_environment` body field on `POST /releases/internal`, populated from FORKLAUNCH_TARGET_ENVIRONMENT — lets the worker pin the fan-out env matched by the webhook instead of falling back to the org default.
- `get_git_branch`: honor FORKLAUNCH_GIT_BRANCH first, then handle detached HEAD via `git for-each-ref --points-at HEAD` so the worker's checkout-by-sha flow still records the branch on the release row.
- Git-release mode: stop hard-coding `git checkout main && git pull`; require a clean working tree and use whatever branch is currently checked out.
- Add BETTER_AUTH_URL and CORS_ORIGINS to is_platform_managed_var so they emit origin=platform in manifest.requiredEnvironmentVariables (validator skips them at deploy time, dashboard stops asking the user to fill them).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional target environment field support for release creation (configured via environment variable).
  * Added environment variable override for git branch detection.

* **Bug Fixes / Improvements**
  * Release creation from git now requires a clean working tree and releases from the currently checked-out branch/commit instead of auto-pulling main.
  * Enhanced git branch detection with robust fallback strategies for detached HEAD scenarios.
  * Improved authentication and signing flexibility for platform API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->