### PR TITLE
feat(observability): define and emit standard HTTP metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,33 @@ app.listen(8000, () => {
 
 ## Documentation
 
+### Custom Metrics
+
+Generated applications share a metrics definition in `blueprint/monitoring/metricsDefinitions.ts`. The standard HTTP metrics use the same names that are emitted to OpenTelemetry and exposed through Prometheus:
+
+| Metric | Type | Labels | What it tracks |
+|:-------|:-----|:-------|:---------------|
+| `http_requests_total` | counter | `service.name`, `application.id`, `api.name`, `http.request.method`, `http.route`, `http.response.status_code` | Total number of HTTP requests received |
+| `http_request_duration_ms` | histogram | `service.name`, `application.id`, `api.name`, `http.request.method`, `http.route`, `http.response.status_code` | Distribution of request durations in milliseconds |
+| `http_errors_total` | counter | `service.name`, `application.id`, `api.name`, `http.request.method`, `http.route`, `http.response.status_code` | Total number of HTTP requests that returned an error (4xx/5xx) |
+| `http_requests_in_flight` | upDownCounter | `service.name` | Number of HTTP requests currently being processed |
+
+To add a custom metric, add an entry to the `metricsDefinitions` object:
+
+```ts
+export const metrics = metricsDefinitions({
+  http_requests_total: 'counter',
+  http_request_duration_ms: 'histogram',
+  http_errors_total: 'counter',
+  http_requests_in_flight: 'upDownCounter',
+
+  // Custom: count successful deployments.
+  deployments_completed: 'counter'
+});
+```
+
+Use counters for totals and event counts, histograms for distributions such as latency or payload size, gauges for directly observed current values, and up-down counters for values that change through increments and decrements such as in-flight requests.
+
 ### Guides
 | Guide | Description |
 |:------|:------------|

--- a/blueprint/monitoring/metricsDefinitions.ts
+++ b/blueprint/monitoring/metricsDefinitions.ts
@@ -3,5 +3,19 @@ import { metricsDefinitions } from '@forklaunch/core/http';
 export type Metrics = typeof metrics;
 
 export const metrics = metricsDefinitions({
-  customMetric: 'counter'
+  // Request rate: total HTTP requests received.
+  // Labels: service.name, application.id, api.name, http.request.method, http.route, http.response.status_code.
+  http_requests_total: 'counter',
+
+  // Latency: distribution of request durations in milliseconds.
+  // Labels: service.name, application.id, api.name, http.request.method, http.route, http.response.status_code.
+  http_request_duration_ms: 'histogram',
+
+  // Error count: total HTTP requests that returned an error (4xx/5xx).
+  // Labels: service.name, application.id, api.name, http.request.method, http.route, http.response.status_code.
+  http_errors_total: 'counter',
+
+  // Saturation: number of HTTP requests currently being processed.
+  // Labels: service.name.
+  http_requests_in_flight: 'upDownCounter'
 });

--- a/blueprint/monitoring/metricsDefinitions.ts
+++ b/blueprint/monitoring/metricsDefinitions.ts
@@ -4,18 +4,14 @@ export type Metrics = typeof metrics;
 
 export const metrics = metricsDefinitions({
   // Request rate: total HTTP requests received.
-  // Labels: service.name, application.id, api.name, http.request.method, http.route, http.response.status_code.
   http_requests_total: 'counter',
 
   // Latency: distribution of request durations in milliseconds.
-  // Labels: service.name, application.id, api.name, http.request.method, http.route, http.response.status_code.
   http_request_duration_ms: 'histogram',
 
   // Error count: total HTTP requests that returned an error (4xx/5xx).
-  // Labels: service.name, application.id, api.name, http.request.method, http.route, http.response.status_code.
   http_errors_total: 'counter',
 
   // Saturation: number of HTTP requests currently being processed.
-  // Labels: service.name.
   http_requests_in_flight: 'upDownCounter'
 });

--- a/framework/core/src/http/middleware/request/createContext.middleware.ts
+++ b/framework/core/src/http/middleware/request/createContext.middleware.ts
@@ -85,19 +85,32 @@ export function createContext<
       requestStartTime: Date.now()
     };
 
-    httpRequestsInFlightCounter.add(1, {
-      [OTEL_ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME')
-    });
+    const serviceName = getEnvVar('OTEL_SERVICE_NAME') || 'unknown';
+    const inFlightAttrs = {
+      [OTEL_ATTR_SERVICE_NAME]: serviceName
+    };
+    let inFlightActive = true;
+
+    const decrementInFlight = () => {
+      if (!inFlightActive) {
+        return;
+      }
+
+      httpRequestsInFlightCounter.add(-1, inFlightAttrs);
+      inFlightActive = false;
+    };
+
+    httpRequestsInFlightCounter.add(1, inFlightAttrs);
+    res.on('finish', decrementInFlight);
+    res.on('close', decrementInFlight);
+    res.on('error', decrementInFlight);
 
     const span = trace.getSpan(context.active());
 
     if (span != null) {
       req.context.span = span;
       req.context.span?.setAttribute(ATTR_CORRELATION_ID, correlationId);
-      req.context.span?.setAttribute(
-        ATTR_SERVICE_NAME,
-        getEnvVar('OTEL_SERVICE_NAME')
-      );
+      req.context.span?.setAttribute(ATTR_SERVICE_NAME, serviceName);
     }
 
     next?.();

--- a/framework/core/src/http/middleware/request/createContext.middleware.ts
+++ b/framework/core/src/http/middleware/request/createContext.middleware.ts
@@ -1,11 +1,13 @@
 import { getEnvVar } from '@forklaunch/common';
 import { AnySchemaValidator } from '@forklaunch/validator';
 import { context, trace } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME as OTEL_ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { v4 } from 'uuid';
 import {
   ATTR_CORRELATION_ID,
   ATTR_SERVICE_NAME
 } from '../../telemetry/constants';
+import { httpRequestsInFlightCounter } from '../../telemetry/openTelemetryCollector';
 import {
   ExpressLikeSchemaHandler,
   ForklaunchNextFunction,
@@ -79,8 +81,13 @@ export function createContext<
     ).setHeader('x-correlation-id', correlationId);
 
     req.context = {
-      correlationId: correlationId
+      correlationId: correlationId,
+      requestStartTime: Date.now()
     };
+
+    httpRequestsInFlightCounter.add(1, {
+      [OTEL_ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME')
+    });
 
     const span = trace.getSpan(context.active());
 

--- a/framework/core/src/http/telemetry/openTelemetryCollector.ts
+++ b/framework/core/src/http/telemetry/openTelemetryCollector.ts
@@ -259,3 +259,37 @@ export const httpServerDurationHistogram = metrics
     description: 'Duration of HTTP server requests',
     unit: 's'
   });
+
+export const httpRequestDurationMsHistogram = metrics
+  .getMeter(getEnvVar('OTEL_SERVICE_NAME') || 'unknown')
+  .createHistogram<{
+    [ATTR_SERVICE_NAME]: string;
+    [ATTR_APPLICATION_ID]?: string;
+    [ATTR_API_NAME]: string;
+    [ATTR_HTTP_REQUEST_METHOD]: string;
+    [ATTR_HTTP_ROUTE]: string;
+    [ATTR_HTTP_RESPONSE_STATUS_CODE]: number;
+  }>('http_request_duration_ms', {
+    description: 'Duration of HTTP requests in milliseconds'
+  });
+
+export const httpErrorsTotalCounter = metrics
+  .getMeter(getEnvVar('OTEL_SERVICE_NAME') || 'unknown')
+  .createCounter<{
+    [ATTR_SERVICE_NAME]: string;
+    [ATTR_APPLICATION_ID]?: string;
+    [ATTR_API_NAME]: string;
+    [ATTR_HTTP_REQUEST_METHOD]: string;
+    [ATTR_HTTP_ROUTE]: string;
+    [ATTR_HTTP_RESPONSE_STATUS_CODE]: number;
+  }>('http_errors_total', {
+    description: 'Total number of HTTP errors (4xx/5xx)'
+  });
+
+export const httpRequestsInFlightCounter = metrics
+  .getMeter(getEnvVar('OTEL_SERVICE_NAME') || 'unknown')
+  .createUpDownCounter<{
+    [ATTR_SERVICE_NAME]: string;
+  }>('http_requests_in_flight', {
+    description: 'Number of HTTP requests currently in flight'
+  });

--- a/framework/core/src/http/telemetry/recordMetric.ts
+++ b/framework/core/src/http/telemetry/recordMetric.ts
@@ -17,7 +17,6 @@ import { ATTR_API_NAME, ATTR_APPLICATION_ID } from './constants';
 import {
   httpErrorsTotalCounter,
   httpRequestDurationMsHistogram,
-  httpRequestsInFlightCounter,
   httpRequestsTotalCounter
 } from './openTelemetryCollector';
 
@@ -54,8 +53,9 @@ export function recordMetric<
     return;
   }
 
+  const serviceName = getEnvVar('OTEL_SERVICE_NAME') || 'unknown';
   const attrs = {
-    [ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME'),
+    [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_APPLICATION_ID]: getEnvVar('OTEL_APPLICATION_ID'),
     [ATTR_API_NAME]: req.contractDetails?.name,
     [ATTR_HTTP_REQUEST_METHOD]: req.method,
@@ -74,10 +74,6 @@ export function recordMetric<
   if (Number(res.statusCode) >= 400) {
     httpErrorsTotalCounter.add(1, attrs);
   }
-
-  httpRequestsInFlightCounter.add(-1, {
-    [ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME')
-  });
 
   res.metricRecorded = true;
 }

--- a/framework/core/src/http/telemetry/recordMetric.ts
+++ b/framework/core/src/http/telemetry/recordMetric.ts
@@ -14,7 +14,12 @@ import {
   VersionedRequests
 } from '..';
 import { ATTR_API_NAME, ATTR_APPLICATION_ID } from './constants';
-import { httpRequestsTotalCounter } from './openTelemetryCollector';
+import {
+  httpErrorsTotalCounter,
+  httpRequestDurationMsHistogram,
+  httpRequestsInFlightCounter,
+  httpRequestsTotalCounter
+} from './openTelemetryCollector';
 
 export function recordMetric<
   SV extends AnySchemaValidator,
@@ -49,13 +54,30 @@ export function recordMetric<
     return;
   }
 
-  httpRequestsTotalCounter.add(1, {
+  const attrs = {
     [ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME'),
     [ATTR_APPLICATION_ID]: getEnvVar('OTEL_APPLICATION_ID'),
     [ATTR_API_NAME]: req.contractDetails?.name,
     [ATTR_HTTP_REQUEST_METHOD]: req.method,
     [ATTR_HTTP_ROUTE]: req.originalPath,
     [ATTR_HTTP_RESPONSE_STATUS_CODE]: Number(res.statusCode) || 0
+  };
+
+  httpRequestsTotalCounter.add(1, attrs);
+
+  const durationMs =
+    req.context?.requestStartTime != null
+      ? Date.now() - req.context.requestStartTime
+      : 0;
+  httpRequestDurationMsHistogram.record(durationMs, attrs);
+
+  if (Number(res.statusCode) >= 400) {
+    httpErrorsTotalCounter.add(1, attrs);
+  }
+
+  httpRequestsInFlightCounter.add(-1, {
+    [ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME')
   });
+
   res.metricRecorded = true;
 }

--- a/framework/core/src/http/types/apiDefinition.types.ts
+++ b/framework/core/src/http/types/apiDefinition.types.ts
@@ -49,6 +49,8 @@ export interface RequestContext {
   idempotencyKey?: string;
   /** Active OpenTelemetry Span */
   span?: Span;
+  /** Wall-clock timestamp (ms) when the request context was created, used for duration metrics */
+  requestStartTime?: number;
 }
 
 export interface ForklaunchBaseRequest<


### PR DESCRIPTION
## Summary

Implements OBS-01 in the upstream `forklaunch` repo rather than the generated `forklaunch-platform` output.

This replaces the blueprint `customMetric` stub with the standard HTTP metric set, documents metric names/types/labels, and adds framework emission for request duration, error count, and in-flight request metrics.

## Changes

- Replaces `customMetric` in `blueprint/monitoring/metricsDefinitions.ts` with:
  - `http_requests_total`
  - `http_request_duration_ms`
  - `http_errors_total`
  - `http_requests_in_flight`
- Keeps `metricsDefinitions` as the existing name/type map; labels are documented in README/comments and attached when metrics are recorded by the framework.
- Adds README documentation for metric names, types, labels, and custom metric usage.
- Adds framework instruments for request duration, error count, and in-flight requests.
- Tracks request start time so duration can be recorded.
- Increments/decrements in-flight requests around the request lifecycle.

## Acceptance Criteria Status

- Standard metrics defined and documented (name, type, labels): covered. Names/types are defined in the blueprint metric map; labels are documented and emitted as OpenTelemetry attributes when the metrics are recorded.
- README note on how to add a custom metric: covered.
- Emitted by a sample service and visible in Prometheus: partially verified with the temporary local smoke test below; reviewer guidance requested on whether to wire the built-in sample worker to local framework packages for full end-to-end validation.

## Verification

- `pnpm --filter @forklaunch/blueprint-monitoring build` passes.
- GitHub checks are passing for blueprint/framework builds and code scanning.
- Smoke-tested a temporary local sample service through OTLP -> collector -> Prometheus.
- Confirmed Prometheus exposes:
  - `http_requests_total`
  - `http_request_duration_ms_count`
  - `http_request_duration_ms_sum`
  - `http_request_duration_ms_bucket`
  - `http_errors_total`
  - `http_requests_in_flight`

## Verification Note

The built-in `blueprint/sample-worker` currently resolves `@forklaunch/core` to the installed published package (`@forklaunch/core@1.5.2`), not this branch’s local `framework/core` changes.

Because of that, running `blueprint/sample-worker` as-is would verify the monitoring stack, but would not exercise this branch’s framework emission changes.

Before adding package-linking or workspace plumbing, I’d like to confirm the preferred verification path: should OBS-01 wire `blueprint/sample-worker` to the local framework packages for end-to-end validation, or is framework-level coverage plus the OTLP/Prometheus smoke test sufficient for this ramp task?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP metrics now automatically tracked: total requests, request duration, error rates, and in-flight request saturation.
  * Custom metrics can be configured via the metrics definition object.

* **Documentation**
  * Added comprehensive guide on defining OpenTelemetry/Prometheus HTTP metrics, including standard metric types (counters, histograms, gauges, up-down counters) and instructions for custom metric setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->