### PR TITLE
[FOR-94] Add observe status CLI scaffold

### DIFF
--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 
-use anyhow::{Result, bail};
-
 use crate::{choice, core::choices::Choice};
 
 // --- Environment Detection ---------------------------------------------------
@@ -16,6 +14,7 @@ const DEV_BILLING_API_URL: &str = "http://localhost:8000";
 const DEV_PLATFORM_UI_URL: &str = "http://localhost:5173";
 
 const PROD_PLATFORM_MANAGEMENT_API_URL: &str = "https://platform-management.forklaunch.com";
+const PROD_OBSERVABILITY_API_URL: &str = "https://observability-api.forklaunch.com";
 const PROD_IAM_API_URL: &str = "https://iam.forklaunch.com";
 const PROD_BILLING_API_URL: &str = "https://billing.forklaunch.com";
 const PROD_PLATFORM_UI_URL: &str = "https://forklaunch.com";
@@ -48,18 +47,15 @@ pub(crate) fn get_platform_management_api_url() -> String {
     })
 }
 
-pub(crate) fn get_observability_api_url() -> Result<String> {
-    if let Ok(api_url) = std::env::var("FORKLAUNCH_OBSERVABILITY_API_URL") {
-        return Ok(api_url);
-    }
-
-    if is_dev_build() {
-        return Ok(DEV_OBSERVABILITY_API_URL.to_string());
-    }
-
-    bail!(
-        "FORKLAUNCH_OBSERVABILITY_API_URL is required because the production observability API URL is not configured"
-    )
+pub(crate) fn get_observability_api_url() -> String {
+    std::env::var("FORKLAUNCH_OBSERVABILITY_API_URL").unwrap_or_else(|_| {
+        if is_dev_build() {
+            DEV_OBSERVABILITY_API_URL
+        } else {
+            PROD_OBSERVABILITY_API_URL
+        }
+        .to_string()
+    })
 }
 
 pub(crate) fn get_iam_api_url() -> String {

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -48,14 +48,18 @@ pub(crate) fn get_platform_management_api_url() -> String {
 }
 
 pub(crate) fn get_observability_api_url() -> String {
-    std::env::var("FORKLAUNCH_OBSERVABILITY_API_URL").unwrap_or_else(|_| {
-        if is_dev_build() {
-            DEV_OBSERVABILITY_API_URL
-        } else {
-            PROD_OBSERVABILITY_API_URL
-        }
-        .to_string()
-    })
+    std::env::var("FORKLAUNCH_OBSERVABILITY_API_URL")
+        .ok()
+        .map(|api_url| api_url.trim().to_string())
+        .filter(|api_url| !api_url.is_empty())
+        .unwrap_or_else(|| {
+            if is_dev_build() {
+                DEV_OBSERVABILITY_API_URL
+            } else {
+                PROD_OBSERVABILITY_API_URL
+            }
+            .to_string()
+        })
 }
 
 pub(crate) fn get_iam_api_url() -> String {

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use anyhow::{Result, bail};
+
 use crate::{choice, core::choices::Choice};
 
 // --- Environment Detection ---------------------------------------------------
@@ -8,6 +10,7 @@ use crate::{choice, core::choices::Choice};
 // All URLs can be overridden via environment variables.
 
 const DEV_PLATFORM_MANAGEMENT_API_URL: &str = "http://localhost:8004";
+const DEV_OBSERVABILITY_API_URL: &str = "http://localhost:8007";
 const DEV_IAM_API_URL: &str = "http://localhost:8001";
 const DEV_BILLING_API_URL: &str = "http://localhost:8000";
 const DEV_PLATFORM_UI_URL: &str = "http://localhost:5173";
@@ -43,6 +46,20 @@ pub(crate) fn get_platform_management_api_url() -> String {
         }
         .to_string()
     })
+}
+
+pub(crate) fn get_observability_api_url() -> Result<String> {
+    if let Ok(api_url) = std::env::var("FORKLAUNCH_OBSERVABILITY_API_URL") {
+        return Ok(api_url);
+    }
+
+    if is_dev_build() {
+        return Ok(DEV_OBSERVABILITY_API_URL.to_string());
+    }
+
+    bail!(
+        "FORKLAUNCH_OBSERVABILITY_API_URL is required because the production observability API URL is not configured"
+    )
 }
 
 pub(crate) fn get_iam_api_url() -> String {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,7 @@ use init::InitCommand;
 use integrate::IntegrateCommand;
 use login::LoginCommand;
 use logout::LogoutCommand;
+use observe::ObserveCommand;
 use openapi::OpenApiCommand;
 use release::ReleaseCommand;
 use version::VersionCommand;
@@ -35,6 +36,7 @@ mod init;
 mod integrate;
 mod login;
 mod logout;
+mod observe;
 mod openapi;
 mod prompt;
 mod release;
@@ -62,6 +64,7 @@ fn main() -> Result<()> {
     let integrate = IntegrateCommand::new();
     let login = LoginCommand::new();
     let logout = LogoutCommand::new();
+    let observe = ObserveCommand::new();
     let openapi = OpenApiCommand::new();
     let release = ReleaseCommand::new();
     let sdk = SdkCommand::new();
@@ -87,6 +90,7 @@ fn main() -> Result<()> {
         .subcommand(release.command())
         .subcommand(login.command())
         .subcommand(logout.command())
+        .subcommand(observe.command())
         .subcommand(sdk.command())
         .subcommand(whoami.command())
         .subcommand(version.command())
@@ -112,6 +116,7 @@ fn main() -> Result<()> {
         Some(("release", sub_matches)) => release.handler(sub_matches),
         Some(("login", sub_matches)) => login.handler(sub_matches),
         Some(("logout", sub_matches)) => logout.handler(sub_matches),
+        Some(("observe", sub_matches)) => observe.handler(sub_matches),
         Some(("sdk", sub_matches)) => sdk.handler(sub_matches),
         Some(("whoami", sub_matches)) => whoami.handler(sub_matches),
         Some(("version", sub_matches)) => version.handler(sub_matches),

--- a/cli/src/observe/mod.rs
+++ b/cli/src/observe/mod.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod status;
+
+use status::StatusCommand;
+
+#[derive(Debug)]
+pub(crate) struct ObserveCommand {
+    status: StatusCommand,
+}
+
+impl ObserveCommand {
+    pub(crate) fn new() -> Self {
+        Self {
+            status: StatusCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for ObserveCommand {
+    fn command(&self) -> Command {
+        command(
+            "observe",
+            "Inspect logs, metrics, traces, and live health for a ForkLaunch application",
+        )
+        .subcommand(self.status.command())
+        .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("status", sub_matches)) => self.status.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/observe/status.rs
+++ b/cli/src/observe/status.rs
@@ -208,13 +208,13 @@ impl SignalStatus {
             || self.traces == SignalHealth::Degraded
         {
             SignalHealth::Degraded
-        } else if self.metrics == SignalHealth::Unknown
-            || self.logs == SignalHealth::Unknown
-            || self.traces == SignalHealth::Unknown
+        } else if self.metrics == SignalHealth::Healthy
+            || self.logs == SignalHealth::Healthy
+            || self.traces == SignalHealth::Healthy
         {
-            SignalHealth::Unknown
-        } else {
             SignalHealth::Healthy
+        } else {
+            SignalHealth::Unknown
         }
     }
 }
@@ -347,11 +347,10 @@ fn metric_label(name: &str) -> String {
 }
 
 fn classify_metrics(monitoring: &ApplicationMonitoringResponse) -> SignalHealth {
-    if monitoring.available == Some(false) {
-        return SignalHealth::Unknown;
+    match monitoring.available {
+        Some(true) => SignalHealth::Healthy,
+        Some(false) | None => SignalHealth::Unknown,
     }
-
-    SignalHealth::Healthy
 }
 
 #[cfg(test)]
@@ -389,14 +388,33 @@ mod tests {
     }
 
     #[test]
-    fn unknown_metrics_drive_overall_status() {
+    fn healthy_metrics_drive_overall_status_when_other_signals_are_unknown() {
+        let signals = SignalStatus {
+            metrics: SignalHealth::Healthy,
+            logs: SignalHealth::Unknown,
+            traces: SignalHealth::Unknown,
+        };
+
+        assert_eq!(signals.overall(), SignalHealth::Healthy);
+    }
+
+    #[test]
+    fn all_unknown_signals_drive_unknown_overall_status() {
         let signals = SignalStatus {
             metrics: SignalHealth::Unknown,
-            logs: SignalHealth::Healthy,
-            traces: SignalHealth::Healthy,
+            logs: SignalHealth::Unknown,
+            traces: SignalHealth::Unknown,
         };
 
         assert_eq!(signals.overall(), SignalHealth::Unknown);
+    }
+
+    #[test]
+    fn omitted_availability_is_unknown() {
+        let mut monitoring = monitoring(0.2, 120.0, 99.95);
+        monitoring.available = None;
+
+        assert_eq!(classify_metrics(&monitoring), SignalHealth::Unknown);
     }
 
     #[test]

--- a/cli/src/observe/status.rs
+++ b/cli/src/observe/status.rs
@@ -1,0 +1,327 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::get_observability_api_url,
+    core::{
+        command::command,
+        hmac::AuthMode,
+        http_client::get_with_auth,
+        validate::{require_integration, require_manifest},
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct StatusCommand;
+
+impl StatusCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for StatusCommand {
+    fn command(&self) -> Command {
+        command(
+            "status",
+            "Print a one-screen observability health summary for an environment",
+        )
+        .arg(
+            Arg::new("base_path")
+                .short('p')
+                .long("path")
+                .help("The application path"),
+        )
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to inspect (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .context("--environment is required")?
+            .to_string();
+        let json_output = matches.get_flag("json");
+
+        let monitoring = fetch_application_monitoring(&application_id, &environment)?;
+        let status = ObserveStatus::from_monitoring(environment, monitoring);
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&status)?);
+        } else {
+            print_status(&status)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn fetch_application_monitoring(
+    application_id: &str,
+    environment: &str,
+) -> Result<ApplicationMonitoringResponse> {
+    let api_url = get_observability_api_url()?;
+    let url = format!(
+        "{}/applications/{}/monitoring?environment={}&timeRange=1h",
+        api_url, application_id, environment
+    );
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach observability API")?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse observability status response")
+}
+
+fn print_status(status: &ObserveStatus) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+    writeln!(stdout, "Observability status for {}", status.environment)?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    write!(stdout, "  Overall: ")?;
+    write_health(&mut stdout, &status.overall_status)?;
+    writeln!(stdout)?;
+    writeln!(stdout)?;
+
+    stdout.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(stdout, "  Signals")?;
+    stdout.reset()?;
+    print_signal(&mut stdout, "Metrics", &status.signals.metrics)?;
+    print_signal(&mut stdout, "Logs", &status.signals.logs)?;
+    print_signal(&mut stdout, "Traces", &status.signals.traces)?;
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(stdout, "  Metrics")?;
+    stdout.reset()?;
+    writeln!(
+        stdout,
+        "    Request rate: {:.2} req/s",
+        status.metrics.request_rate
+    )?;
+    writeln!(
+        stdout,
+        "    Error rate:   {:.2}%",
+        status.metrics.error_rate
+    )?;
+    writeln!(
+        stdout,
+        "    Latency p95:  {:.2} ms",
+        status.metrics.latency_p95
+    )?;
+    writeln!(stdout, "    Uptime:       {:.2}%", status.metrics.uptime)?;
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn print_signal(out: &mut StandardStream, label: &str, health: &SignalHealth) -> Result<()> {
+    write!(out, "    {:<8} ", label)?;
+    write_health(out, health)?;
+    writeln!(out)?;
+    Ok(())
+}
+
+fn write_health(out: &mut StandardStream, health: &SignalHealth) -> Result<()> {
+    let color = match health {
+        SignalHealth::Healthy => Color::Green,
+        SignalHealth::Degraded => Color::Yellow,
+        SignalHealth::Unhealthy => Color::Red,
+        SignalHealth::Unknown => Color::White,
+    };
+    out.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+    write!(out, "{}", health)?;
+    out.reset()?;
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ObserveStatus {
+    environment: String,
+    overall_status: SignalHealth,
+    signals: SignalStatus,
+    metrics: StatusMetrics,
+}
+
+impl ObserveStatus {
+    fn from_monitoring(environment: String, monitoring: ApplicationMonitoringResponse) -> Self {
+        let metrics_health = classify_metrics(&monitoring);
+        let signals = SignalStatus {
+            metrics: metrics_health.clone(),
+            logs: SignalHealth::Unknown,
+            traces: SignalHealth::Unknown,
+        };
+        let overall_status = signals.overall();
+
+        Self {
+            environment,
+            overall_status,
+            signals,
+            metrics: StatusMetrics {
+                request_rate: monitoring.request_rate,
+                error_rate: monitoring.error_rate,
+                latency_p95: monitoring.latency.p95,
+                uptime: monitoring.uptime,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SignalStatus {
+    metrics: SignalHealth,
+    logs: SignalHealth,
+    traces: SignalHealth,
+}
+
+impl SignalStatus {
+    fn overall(&self) -> SignalHealth {
+        if self.metrics == SignalHealth::Unhealthy
+            || self.logs == SignalHealth::Unhealthy
+            || self.traces == SignalHealth::Unhealthy
+        {
+            SignalHealth::Unhealthy
+        } else if self.metrics == SignalHealth::Degraded
+            || self.logs == SignalHealth::Degraded
+            || self.traces == SignalHealth::Degraded
+        {
+            SignalHealth::Degraded
+        } else if self.metrics == SignalHealth::Unknown
+            || self.logs == SignalHealth::Unknown
+            || self.traces == SignalHealth::Unknown
+        {
+            SignalHealth::Unknown
+        } else {
+            SignalHealth::Healthy
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum SignalHealth {
+    Healthy,
+    Degraded,
+    Unhealthy,
+    Unknown,
+}
+
+impl std::fmt::Display for SignalHealth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignalHealth::Healthy => write!(f, "healthy"),
+            SignalHealth::Degraded => write!(f, "degraded"),
+            SignalHealth::Unhealthy => write!(f, "unhealthy"),
+            SignalHealth::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusMetrics {
+    request_rate: f64,
+    error_rate: f64,
+    latency_p95: f64,
+    uptime: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationMonitoringResponse {
+    request_rate: f64,
+    latency: LatencyResponse,
+    error_rate: f64,
+    uptime: f64,
+    #[serde(default)]
+    available: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LatencyResponse {
+    p95: f64,
+}
+
+fn classify_metrics(monitoring: &ApplicationMonitoringResponse) -> SignalHealth {
+    if monitoring.available == Some(false) {
+        return SignalHealth::Unknown;
+    }
+
+    SignalHealth::Healthy
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitoring(error_rate: f64, p95: f64, uptime: f64) -> ApplicationMonitoringResponse {
+        ApplicationMonitoringResponse {
+            request_rate: 12.0,
+            latency: LatencyResponse { p95 },
+            error_rate,
+            uptime,
+            available: Some(true),
+        }
+    }
+
+    #[test]
+    fn classifies_healthy_metrics() {
+        assert_eq!(
+            classify_metrics(&monitoring(0.2, 120.0, 99.95)),
+            SignalHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn reports_available_metrics_as_healthy_without_threshold_policy() {
+        assert_eq!(
+            classify_metrics(&monitoring(7.5, 1_200.0, 98.0)),
+            SignalHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn unknown_metrics_drive_overall_status() {
+        let signals = SignalStatus {
+            metrics: SignalHealth::Unknown,
+            logs: SignalHealth::Healthy,
+            traces: SignalHealth::Healthy,
+        };
+
+        assert_eq!(signals.overall(), SignalHealth::Unknown);
+    }
+}

--- a/cli/src/observe/status.rs
+++ b/cli/src/observe/status.rs
@@ -1,8 +1,9 @@
-use std::io::Write;
+use std::{collections::BTreeMap, io::Write};
 
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::{
@@ -78,7 +79,7 @@ fn fetch_application_monitoring(
     application_id: &str,
     environment: &str,
 ) -> Result<ApplicationMonitoringResponse> {
-    let api_url = get_observability_api_url()?;
+    let api_url = get_observability_api_url();
     let url = format!(
         "{}/applications/{}/monitoring?environment={}&timeRange=1h",
         api_url, application_id, environment
@@ -126,22 +127,14 @@ fn print_status(status: &ObserveStatus) -> Result<()> {
     stdout.set_color(ColorSpec::new().set_bold(true))?;
     writeln!(stdout, "  Metrics")?;
     stdout.reset()?;
-    writeln!(
-        stdout,
-        "    Request rate: {:.2} req/s",
-        status.metrics.request_rate
-    )?;
-    writeln!(
-        stdout,
-        "    Error rate:   {:.2}%",
-        status.metrics.error_rate
-    )?;
-    writeln!(
-        stdout,
-        "    Latency p95:  {:.2} ms",
-        status.metrics.latency_p95
-    )?;
-    writeln!(stdout, "    Uptime:       {:.2}%", status.metrics.uptime)?;
+    for metric in &status.metrics {
+        writeln!(
+            stdout,
+            "    {:<18} {}",
+            format!("{}:", metric.label),
+            metric.display_value
+        )?;
+    }
     writeln!(stdout)?;
 
     Ok(())
@@ -173,7 +166,7 @@ struct ObserveStatus {
     environment: String,
     overall_status: SignalHealth,
     signals: SignalStatus,
-    metrics: StatusMetrics,
+    metrics: Vec<StatusMetric>,
 }
 
 impl ObserveStatus {
@@ -190,12 +183,7 @@ impl ObserveStatus {
             environment,
             overall_status,
             signals,
-            metrics: StatusMetrics {
-                request_rate: monitoring.request_rate,
-                error_rate: monitoring.error_rate,
-                latency_p95: monitoring.latency.p95,
-                uptime: monitoring.uptime,
-            },
+            metrics: monitoring.metrics(),
         }
     }
 }
@@ -253,11 +241,11 @@ impl std::fmt::Display for SignalHealth {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct StatusMetrics {
-    request_rate: f64,
-    error_rate: f64,
-    latency_p95: f64,
-    uptime: f64,
+struct StatusMetric {
+    name: String,
+    label: String,
+    value: Value,
+    display_value: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -269,11 +257,93 @@ struct ApplicationMonitoringResponse {
     uptime: f64,
     #[serde(default)]
     available: Option<bool>,
+    #[serde(flatten)]
+    additional_metrics: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
 struct LatencyResponse {
     p95: f64,
+    #[serde(flatten)]
+    additional_percentiles: BTreeMap<String, Value>,
+}
+
+impl ApplicationMonitoringResponse {
+    fn metrics(&self) -> Vec<StatusMetric> {
+        let mut metrics = vec![
+            StatusMetric::number("requestRate", "Request rate", self.request_rate, "req/s"),
+            StatusMetric::number("errorRate", "Error rate", self.error_rate, "%"),
+            StatusMetric::number("latency.p95", "Latency p95", self.latency.p95, "ms"),
+            StatusMetric::number("uptime", "Uptime", self.uptime, "%"),
+        ];
+
+        for (name, value) in &self.latency.additional_percentiles {
+            metrics.push(StatusMetric::from_value(
+                format!("latency.{name}"),
+                format!("Latency {}", metric_label(name)),
+                value.clone(),
+                Some("ms"),
+            ));
+        }
+
+        for (name, value) in &self.additional_metrics {
+            metrics.push(StatusMetric::from_value(
+                name.clone(),
+                metric_label(name),
+                value.clone(),
+                None,
+            ));
+        }
+
+        metrics
+    }
+}
+
+impl StatusMetric {
+    fn number(name: &str, label: &str, value: f64, unit: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            label: label.to_string(),
+            value: Value::from(value),
+            display_value: format!("{value:.2} {unit}"),
+        }
+    }
+
+    fn from_value(name: String, label: String, value: Value, unit: Option<&str>) -> Self {
+        let display_value = match (&value, unit) {
+            (Value::Number(number), Some(unit)) => format!("{number} {unit}"),
+            (Value::Number(number), None) => number.to_string(),
+            (Value::String(value), _) => value.clone(),
+            (Value::Bool(value), _) => value.to_string(),
+            _ => value.to_string(),
+        };
+
+        Self {
+            name,
+            label,
+            value,
+            display_value,
+        }
+    }
+}
+
+fn metric_label(name: &str) -> String {
+    let mut label = String::new();
+
+    for (index, char) in name.chars().enumerate() {
+        if index == 0 {
+            label.push(char.to_ascii_uppercase());
+        } else if char == '_' || char == '-' {
+            label.push(' ');
+        } else if char.is_ascii_uppercase() {
+            label.push(' ');
+            label.push(char.to_ascii_lowercase());
+        } else {
+            label.push(char);
+        }
+    }
+
+    label
 }
 
 fn classify_metrics(monitoring: &ApplicationMonitoringResponse) -> SignalHealth {
@@ -291,10 +361,14 @@ mod tests {
     fn monitoring(error_rate: f64, p95: f64, uptime: f64) -> ApplicationMonitoringResponse {
         ApplicationMonitoringResponse {
             request_rate: 12.0,
-            latency: LatencyResponse { p95 },
+            latency: LatencyResponse {
+                p95,
+                additional_percentiles: BTreeMap::new(),
+            },
             error_rate,
             uptime,
             available: Some(true),
+            additional_metrics: BTreeMap::new(),
         }
     }
 
@@ -323,5 +397,20 @@ mod tests {
         };
 
         assert_eq!(signals.overall(), SignalHealth::Unknown);
+    }
+
+    #[test]
+    fn includes_additional_metrics_in_display_order() {
+        let mut monitoring = monitoring(0.2, 120.0, 99.95);
+        monitoring
+            .additional_metrics
+            .insert("queueDepth".to_string(), Value::from(42));
+
+        let status = ObserveStatus::from_monitoring("dev".to_string(), monitoring);
+
+        assert_eq!(status.metrics.len(), 5);
+        assert_eq!(status.metrics[4].name, "queueDepth");
+        assert_eq!(status.metrics[4].label, "Queue depth");
+        assert_eq!(status.metrics[4].display_value, "42");
     }
 }


### PR DESCRIPTION
References FOR-94.

## Summary

- Register a new `forklaunch observe` command family in the CLI.
- Add `forklaunch observe status -e <env>` with formatted terminal output, `--json` output, and help text.
- Fetch application monitoring using the integrated application id from the local ForkLaunch manifest.
- Default local development to `http://localhost:8007` and production to `https://observability-api.forklaunch.com`, with `FORKLAUNCH_OBSERVABILITY_API_URL` still available as an override.
- Render metrics from a dynamic metric list so additional API-returned metrics/latency percentiles can show up without adding new hardcoded print lines.

## Review notes

- Rohin confirmed the production Observability API DNS target is `https://observability-api.forklaunch.com`.
- The command currently calls the Observability API directly. If this should instead route through Platform Management, I can swap the API client target once the endpoint shape is confirmed.

## Validation

- `cargo test observe::status`
- `cargo check`
- `cargo run --quiet -- observe status --help`
