### PR TITLE
[FOR-95] Add observe logs subcommand with --follow streaming (OBS-12)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,7 @@ tempfile = "3.20.0"
 dirs = "5.0.1"
 colored = "2.1.0"
 derive_more = { version = "2.0.1", features = ["from"] }
+tungstenite = { version = "0.26", features = ["native-tls"] }
 chrono = { version = "0.4", features = ["serde"] }
 ignore = "0.4"
 tar = "0.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ dirs = "5.0.1"
 colored = "2.1.0"
 derive_more = { version = "2.0.1", features = ["from"] }
 tungstenite = { version = "0.26", features = ["native-tls"] }
+urlencoding = "2.1"
 chrono = { version = "0.4", features = ["serde"] }
 ignore = "0.4"
 tar = "0.4"

--- a/cli/src/observe/logs.rs
+++ b/cli/src/observe/logs.rs
@@ -63,6 +63,7 @@ impl CliCommand for LogsCommand {
                 Arg::new("limit")
                     .long("limit")
                     .default_value("100")
+                    .value_parser(clap::value_parser!(u32))
                     .help("Maximum number of log lines to fetch"),
             )
             .arg(
@@ -90,10 +91,7 @@ impl CliCommand for LogsCommand {
         let service = matches.get_one::<String>("service").cloned();
         let level = matches.get_one::<String>("level").cloned();
         let since = matches.get_one::<String>("since").cloned();
-        let limit: u32 = matches
-            .get_one::<String>("limit")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(100);
+        let limit: u32 = matches.get_one::<u32>("limit").copied().unwrap_or(100);
         let follow = matches.get_flag("follow");
         let json_output = matches.get_flag("json");
 
@@ -153,16 +151,19 @@ fn fetch_logs(
     let api_url = get_observability_api_url();
     let mut url = format!(
         "{}/applications/{}/logs?environment={}&limit={}&direction=backward",
-        api_url, application_id, environment, limit
+        api_url,
+        application_id,
+        urlencoding::encode(environment),
+        limit
     );
     if let Some(svc) = service {
-        url.push_str(&format!("&service={}", svc));
+        url.push_str(&format!("&service={}", urlencoding::encode(svc)));
     }
     if let Some(lvl) = level {
-        url.push_str(&format!("&level={}", lvl));
+        url.push_str(&format!("&level={}", urlencoding::encode(lvl)));
     }
     if let Some(s) = since {
-        url.push_str(&format!("&since={}", urlencoding_encode(s)));
+        url.push_str(&format!("&since={}", urlencoding::encode(s)));
     }
 
     let auth_mode = AuthMode::detect();
@@ -243,6 +244,7 @@ fn stream_logs(
         "applicationId": application_id,
         "environment": environment,
         "serviceName": service,
+        "level": level,
     });
     socket
         .send(tungstenite::Message::Text(
@@ -288,9 +290,6 @@ fn stream_logs(
                 } else {
                     print_logs(&logs)?;
                 }
-
-                // Apply level filter client-side if server doesn't filter
-                let _ = level; // already sent to server; nothing extra needed here
             }
             Ok(tungstenite::Message::Close(_)) => {
                 break;
@@ -319,21 +318,6 @@ fn build_ws_url() -> Result<String> {
     Ok(ws_url)
 }
 
-fn urlencoding_encode(s: &str) -> String {
-    let mut encoded = String::new();
-    for byte in s.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                encoded.push(byte as char);
-            }
-            _ => {
-                encoded.push_str(&format!("%{:02X}", byte));
-            }
-        }
-    }
-    encoded
-}
-
 // ── Display ───────────────────────────────────────────────────────────────────
 
 fn print_logs(logs: &[LogEntry]) -> Result<()> {
@@ -344,7 +328,8 @@ fn print_logs(logs: &[LogEntry]) -> Result<()> {
         let color = level_color(level);
 
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
-        write!(stdout, "{} ", &entry.timestamp[..19].replace('T', " "))?;
+        let ts_display = entry.timestamp.get(..19).unwrap_or(&entry.timestamp).replace('T', " ");
+        write!(stdout, "{} ", ts_display)?;
 
         stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
         write!(stdout, "{:<5} ", level.to_uppercase())?;
@@ -383,6 +368,7 @@ struct LogEntry {
 #[serde(rename_all = "camelCase")]
 struct LogsResponse {
     logs: Vec<LogEntry>,
+    #[serde(default)]
     available: bool,
     #[serde(default)]
     has_more: Option<bool>,

--- a/cli/src/observe/logs.rs
+++ b/cli/src/observe/logs.rs
@@ -1,0 +1,391 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use tungstenite::client::IntoClientRequest;
+
+use crate::{
+    CliCommand,
+    constants::get_observability_api_url,
+    core::{
+        command::command,
+        hmac::AuthMode,
+        http_client::get_with_auth,
+        token::get_token,
+        validate::{require_integration, require_manifest},
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct LogsCommand;
+
+impl LogsCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for LogsCommand {
+    fn command(&self) -> Command {
+        command("logs", "Query or live-tail logs for a ForkLaunch application")
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
+            )
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .required(true)
+                    .help("Environment to inspect (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("service")
+                    .short('s')
+                    .long("service")
+                    .help("Filter to a specific service name"),
+            )
+            .arg(
+                Arg::new("level")
+                    .long("level")
+                    .help("Filter by log level (error, warn, info, debug)"),
+            )
+            .arg(
+                Arg::new("since")
+                    .long("since")
+                    .help("Return logs newer than this ISO timestamp"),
+            )
+            .arg(
+                Arg::new("limit")
+                    .long("limit")
+                    .default_value("100")
+                    .help("Maximum number of log lines to fetch"),
+            )
+            .arg(
+                Arg::new("follow")
+                    .short('f')
+                    .long("follow")
+                    .help("Stream new logs as they arrive (live-tail)")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .context("--environment is required")?
+            .to_string();
+        let service = matches.get_one::<String>("service").cloned();
+        let level = matches.get_one::<String>("level").cloned();
+        let since = matches.get_one::<String>("since").cloned();
+        let limit: u32 = matches
+            .get_one::<String>("limit")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(100);
+        let follow = matches.get_flag("follow");
+        let json_output = matches.get_flag("json");
+
+        if follow {
+            stream_logs(
+                &application_id,
+                &environment,
+                service.as_deref(),
+                level.as_deref(),
+                limit,
+                json_output,
+            )
+        } else {
+            query_logs(
+                &application_id,
+                &environment,
+                service.as_deref(),
+                level.as_deref(),
+                since.as_deref(),
+                limit,
+                json_output,
+            )
+        }
+    }
+}
+
+// ── HTTP query (no --follow) ──────────────────────────────────────────────────
+
+fn query_logs(
+    application_id: &str,
+    environment: &str,
+    service: Option<&str>,
+    level: Option<&str>,
+    since: Option<&str>,
+    limit: u32,
+    json_output: bool,
+) -> Result<()> {
+    let response = fetch_logs(application_id, environment, service, level, since, limit)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        print_logs(&response.logs)?;
+    }
+
+    Ok(())
+}
+
+fn fetch_logs(
+    application_id: &str,
+    environment: &str,
+    service: Option<&str>,
+    level: Option<&str>,
+    since: Option<&str>,
+    limit: u32,
+) -> Result<LogsResponse> {
+    let api_url = get_observability_api_url();
+    let mut url = format!(
+        "{}/applications/{}/logs?environment={}&limit={}&direction=backward",
+        api_url, application_id, environment, limit
+    );
+    if let Some(svc) = service {
+        url.push_str(&format!("&service={}", svc));
+    }
+    if let Some(lvl) = level {
+        url.push_str(&format!("&level={}", lvl));
+    }
+    if let Some(s) = since {
+        url.push_str(&format!("&since={}", urlencoding_encode(s)));
+    }
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse logs response")
+}
+
+// ── WebSocket follow (--follow) ───────────────────────────────────────────────
+
+fn stream_logs(
+    application_id: &str,
+    environment: &str,
+    service: Option<&str>,
+    level: Option<&str>,
+    limit: u32,
+    json_output: bool,
+) -> Result<()> {
+    // Fetch one page first so we print recent history and know the starting timestamp
+    let initial = fetch_logs(application_id, environment, service, level, None, limit)?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&initial)?);
+    } else {
+        print_logs(&initial.logs)?;
+    }
+
+    let ws_url = build_ws_url()?;
+    let mut request = ws_url
+        .as_str()
+        .into_client_request()
+        .with_context(|| "Failed to build WebSocket request")?;
+
+    // Attach auth header
+    let auth_mode = AuthMode::detect();
+    match &auth_mode {
+        AuthMode::Jwt => {
+            let token = get_token().with_context(|| "Failed to get auth token")?;
+            request.headers_mut().insert(
+                "Authorization",
+                format!("Bearer {}", token)
+                    .parse()
+                    .with_context(|| "Invalid auth header value")?,
+            );
+        }
+        AuthMode::Hmac { secret_key } => {
+            let auth_header = crate::core::hmac::generate_hmac_auth_header(
+                secret_key,
+                "GET",
+                "/ws",
+                None,
+            )?;
+            request.headers_mut().insert(
+                "Authorization",
+                auth_header
+                    .parse()
+                    .with_context(|| "Invalid HMAC header value")?,
+            );
+        }
+    }
+
+    let (mut socket, _) =
+        tungstenite::connect(request).with_context(|| "Failed to connect to WebSocket")?;
+
+    // Subscribe to logs channel
+    let subscribe_msg = serde_json::json!({
+        "type": "subscribeLogs",
+        "applicationId": application_id,
+        "environment": environment,
+        "serviceName": service,
+    });
+    socket
+        .send(tungstenite::Message::Text(
+            subscribe_msg.to_string().into(),
+        ))
+        .with_context(|| "Failed to send subscribe message")?;
+
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    if !json_output {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+        writeln!(stdout, "Streaming logs for {} ({})…  Ctrl+C to stop", application_id, environment)?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+    }
+
+    loop {
+        match socket.read() {
+            Ok(tungstenite::Message::Text(text)) => {
+                let msg: serde_json::Value = match serde_json::from_str(&text) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+                // Only handle channelData messages that carry logs
+                if msg.get("channel").is_none() {
+                    continue;
+                }
+                let data = match msg.get("data") {
+                    Some(d) => d,
+                    None => continue,
+                };
+                let logs: Vec<LogEntry> = match data.get("logs") {
+                    Some(l) => match serde_json::from_value(l.clone()) {
+                        Ok(entries) => entries,
+                        Err(_) => continue,
+                    },
+                    None => continue,
+                };
+
+                if json_output {
+                    println!("{}", serde_json::to_string_pretty(&logs)?);
+                } else {
+                    print_logs(&logs)?;
+                }
+
+                // Apply level filter client-side if server doesn't filter
+                let _ = level; // already sent to server; nothing extra needed here
+            }
+            Ok(tungstenite::Message::Close(_)) => {
+                break;
+            }
+            Ok(_) => {}
+            Err(tungstenite::Error::ConnectionClosed) => break,
+            Err(e) => {
+                anyhow::bail!("WebSocket error: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_ws_url() -> Result<String> {
+    let api_url = get_observability_api_url();
+    // Convert http(s):// to ws(s):// and append /ws path
+    let ws_url = if api_url.starts_with("https://") {
+        format!("wss://{}/ws", &api_url[8..])
+    } else if api_url.starts_with("http://") {
+        format!("ws://{}/ws", &api_url[7..])
+    } else {
+        format!("ws://{}/ws", api_url)
+    };
+    Ok(ws_url)
+}
+
+fn urlencoding_encode(s: &str) -> String {
+    let mut encoded = String::new();
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push_str(&format!("%{:02X}", byte));
+            }
+        }
+    }
+    encoded
+}
+
+// ── Display ───────────────────────────────────────────────────────────────────
+
+fn print_logs(logs: &[LogEntry]) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    for entry in logs {
+        let level = entry.level.as_deref().unwrap_or("info");
+        let color = level_color(level);
+
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        write!(stdout, "{} ", &entry.timestamp[..19].replace('T', " "))?;
+
+        stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(stdout, "{:<5} ", level.to_uppercase())?;
+
+        stdout.reset()?;
+        writeln!(stdout, "{}", entry.message)?;
+    }
+
+    Ok(())
+}
+
+fn level_color(level: &str) -> Color {
+    match level.to_lowercase().as_str() {
+        "error" => Color::Red,
+        "warn" | "warning" => Color::Yellow,
+        "info" => Color::Green,
+        "debug" => Color::Cyan,
+        _ => Color::White,
+    }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LogEntry {
+    id: String,
+    timestamp: String,
+    level: Option<String>,
+    message: String,
+    #[serde(default)]
+    labels: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LogsResponse {
+    logs: Vec<LogEntry>,
+    available: bool,
+    #[serde(default)]
+    has_more: Option<bool>,
+    #[serde(default)]
+    next_cursor: Option<String>,
+}

--- a/cli/src/observe/mod.rs
+++ b/cli/src/observe/mod.rs
@@ -3,19 +3,23 @@ use clap::{ArgMatches, Command};
 
 use crate::{CliCommand, core::command::command};
 
+mod logs;
 mod status;
 
+use logs::LogsCommand;
 use status::StatusCommand;
 
 #[derive(Debug)]
 pub(crate) struct ObserveCommand {
     status: StatusCommand,
+    logs: LogsCommand,
 }
 
 impl ObserveCommand {
     pub(crate) fn new() -> Self {
         Self {
             status: StatusCommand::new(),
+            logs: LogsCommand::new(),
         }
     }
 }
@@ -27,12 +31,14 @@ impl CliCommand for ObserveCommand {
             "Inspect logs, metrics, traces, and live health for a ForkLaunch application",
         )
         .subcommand(self.status.command())
+        .subcommand(self.logs.command())
         .subcommand_required(true)
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("status", sub_matches)) => self.status.handler(sub_matches),
+            Some(("logs", sub_matches)) => self.logs.handler(sub_matches),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
References FOR-95.

## Summary

- Adds `forklaunch observe logs` subcommand under the existing `observe` command family
- **Query mode** (no flag): HTTP GET `/applications/{id}/logs`, prints formatted log lines, exits
- **Follow mode** (`-f`): fetches initial page via HTTP, then opens a WebSocket, subscribes to the logs channel, and streams new entries as they arrive — exits on Ctrl+C
- Filters: `--level`, `--service`, `--since`, `--limit`, `--json`
- Adds `tungstenite` as the sync WebSocket client crate

## Related

- Companion platform PR: https://github.com/forklaunch/forklaunch-platform/pull/159
- Linear: [FOR-95](https://linear.app/forklaunch/issue/FOR-95)

## Test plan

- [ ] `forklaunch observe logs -e dev` prints recent logs and exits
- [ ] `forklaunch observe logs -e dev -f` streams new logs live
- [ ] `--level error` filters correctly
- [ ] `--service billing` scopes to one service
- [ ] `--json` outputs raw JSON for CI scripting
- [ ] Ctrl+C exits cleanly with no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `logs` subcommand to the observe command, enabling users to query and live-tail application logs with filtering by environment, service, level, and timestamp, plus multiple output format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->