### PR TITLE
feat(observe): add observe issues CLI command (FOR-97 / OBS-14)

### DIFF
--- a/cli/src/observe/issues.rs
+++ b/cli/src/observe/issues.rs
@@ -1,0 +1,525 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::get_observability_api_url,
+    core::{
+        command::command,
+        hmac::AuthMode,
+        http_client::{get_with_auth, post_with_auth},
+        validate::{require_integration, require_manifest},
+    },
+};
+
+// ── Top-level command ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub(super) struct IssuesCommand {
+    ack: AckCommand,
+}
+
+impl IssuesCommand {
+    pub(super) fn new() -> Self {
+        Self {
+            ack: AckCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for IssuesCommand {
+    fn command(&self) -> Command {
+        command("issues", "List or acknowledge active issues for a ForkLaunch application")
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
+            )
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .help("Environment to inspect (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("severity")
+                    .long("severity")
+                    .help("Filter by severity (ERROR, ALERT, INCIDENT)"),
+            )
+            .arg(
+                Arg::new("status")
+                    .long("status")
+                    .help("Filter by status (for example: open, acknowledged)"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+            .subcommand(self.ack.command())
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("ack", sub_matches)) => self.ack.handler(sub_matches),
+            _ => list_issues(matches),
+        }
+    }
+}
+
+// ── Ack sub-subcommand ────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct AckCommand;
+
+impl AckCommand {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for AckCommand {
+    fn command(&self) -> Command {
+        command("ack", "Acknowledge an active issue")
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
+            )
+            .arg(
+                Arg::new("id")
+                    .required(true)
+                    .help("The issue ID to acknowledge"),
+            )
+            .arg(
+                Arg::new("acknowledged_by")
+                    .long("acknowledged-by")
+                    .help("User acknowledging the issue (defaults to the logged-in user's email)"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        acknowledge_issue(matches)
+    }
+}
+
+// ── List handler ──────────────────────────────────────────────────────────────
+
+fn list_issues(matches: &ArgMatches) -> Result<()> {
+    let (_app_root, manifest) = require_manifest(matches)?;
+    let application_id = require_integration(&manifest)?;
+    let environment = matches
+        .get_one::<String>("environment")
+        .context("--environment is required for listing issues")?
+        .to_string();
+    let severity = matches.get_one::<String>("severity").cloned();
+    let status = matches.get_one::<String>("status").cloned();
+    let json_output = matches.get_flag("json");
+
+    let response = fetch_issues(&application_id, &environment, severity.as_deref(), status.as_deref())?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        print_issues(&response.issues)?;
+    }
+
+    Ok(())
+}
+
+fn fetch_issues(
+    application_id: &str,
+    environment: &str,
+    severity: Option<&str>,
+    status: Option<&str>,
+) -> Result<IssuesResponse> {
+    let api_url = get_observability_api_url();
+    let mut url = format!(
+        "{}/issues?appId={}&env={}",
+        api_url,
+        urlencoding::encode(application_id),
+        urlencoding::encode(environment),
+    );
+    if let Some(sev) = severity {
+        url.push_str(&format!("&severity={}", urlencoding::encode(sev)));
+    }
+    if let Some(st) = status {
+        url.push_str(&format!("&status={}", urlencoding::encode(st)));
+    }
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let http_status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", http_status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse issues response")
+}
+
+// ── Acknowledge handler ───────────────────────────────────────────────────────
+
+fn acknowledge_issue(matches: &ArgMatches) -> Result<()> {
+    let (_app_root, manifest) = require_manifest(matches)?;
+    let application_id = require_integration(&manifest)?;
+    let issue_id = matches
+        .get_one::<String>("id")
+        .context("issue id is required")?
+        .to_string();
+    let acknowledged_by = matches
+        .get_one::<String>("acknowledged_by")
+        .cloned()
+        .unwrap_or_else(|| resolve_current_user(&application_id));
+    let json_output = matches.get_flag("json");
+
+    let response = post_acknowledge(&issue_id, &acknowledged_by)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        print_ack_result(&issue_id, &acknowledged_by, &response)?;
+    }
+
+    Ok(())
+}
+
+/// Best-effort attempt to identify the current user for the default
+/// `--acknowledged-by` value. Falls back gracefully to "unknown" so that the
+/// acknowledge POST can still proceed without forcing the user to supply the
+/// flag.
+fn resolve_current_user(_application_id: &str) -> String {
+    // Try the FORKLAUNCH_USER env var first (useful in CI / scripted contexts).
+    if let Ok(user) = std::env::var("FORKLAUNCH_USER") {
+        if !user.trim().is_empty() {
+            return user.trim().to_string();
+        }
+    }
+    // Fall back to the OS user name.
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn post_acknowledge(issue_id: &str, acknowledged_by: &str) -> Result<AckResponse> {
+    let api_url = get_observability_api_url();
+    let url = format!("{}/issues/{}/acknowledge", api_url, urlencoding::encode(issue_id));
+
+    let body = serde_json::json!({ "acknowledgedBy": acknowledged_by });
+    let auth_mode = AuthMode::detect();
+    let response =
+        post_with_auth(&auth_mode, &url, body).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let http_status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", http_status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse acknowledge response")
+}
+
+// ── Display ───────────────────────────────────────────────────────────────────
+
+fn print_issues(issues: &[Issue]) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    if issues.is_empty() {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        writeln!(stdout, "No active issues found.")?;
+        stdout.reset()?;
+        return Ok(());
+    }
+
+    writeln!(stdout)?;
+
+    // Header
+    stdout.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(
+        stdout,
+        "  {:<10}  {:<10}  {:<20}  {:<30}  {}",
+        "SEVERITY", "ID", "SERVICE", "TITLE", "FIRST SEEN"
+    )?;
+    stdout.reset()?;
+
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(
+        stdout,
+        "  {:-<10}  {:-<10}  {:-<20}  {:-<30}  {:-<19}",
+        "", "", "", "", ""
+    )?;
+    stdout.reset()?;
+
+    for issue in issues {
+        let severity = issue.severity.as_deref().unwrap_or("UNKNOWN");
+        let color = severity_color(severity);
+
+        stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(stdout, "  {:<10}", severity)?;
+        stdout.reset()?;
+
+        let id_display = issue.id.get(..10).unwrap_or(&issue.id);
+        let service = issue.service_name.as_deref().unwrap_or("-");
+        let title = issue.title.as_deref().unwrap_or("-");
+        let title_truncated = if title.len() > 30 {
+            format!("{}…", &title[..29])
+        } else {
+            title.to_string()
+        };
+        let first_seen = issue
+            .first_seen
+            .as_deref()
+            .and_then(|ts| ts.get(..19))
+            .map(|ts| ts.replace('T', " "))
+            .unwrap_or_else(|| "-".to_string());
+
+        writeln!(
+            stdout,
+            "  {:<10}  {:<20}  {:<30}  {}",
+            id_display, service, title_truncated, first_seen
+        )?;
+    }
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(stdout, "  {} issue(s) found.", issues.len())?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn print_ack_result(issue_id: &str, acknowledged_by: &str, _response: &AckResponse) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
+    write!(stdout, "  Acknowledged")?;
+    stdout.reset()?;
+    writeln!(stdout, "  issue {} by {}", issue_id, acknowledged_by)?;
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn severity_color(severity: &str) -> Color {
+    match severity.to_uppercase().as_str() {
+        "ERROR" => Color::Red,
+        "ALERT" => Color::Yellow,
+        "INCIDENT" => Color::Cyan,
+        _ => Color::White,
+    }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Issue {
+    id: String,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    service_name: Option<String>,
+    #[serde(default)]
+    env: Option<String>,
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    score: Option<f64>,
+    #[serde(default)]
+    first_seen: Option<String>,
+    #[serde(default)]
+    last_seen: Option<String>,
+    #[serde(default)]
+    acknowledged_at: Option<String>,
+    #[serde(default)]
+    acknowledged_by: Option<String>,
+    #[serde(default)]
+    resolved_at: Option<String>,
+    #[serde(default)]
+    resolved_by: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IssuesResponse {
+    issues: Vec<Issue>,
+    #[serde(default)]
+    total: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AckResponse {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    acknowledged_at: Option<String>,
+    #[serde(default)]
+    acknowledged_by: Option<String>,
+    #[serde(flatten)]
+    extra: serde_json::Value,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_color_error_is_red() {
+        assert_eq!(severity_color("ERROR"), Color::Red);
+    }
+
+    #[test]
+    fn severity_color_alert_is_yellow() {
+        assert_eq!(severity_color("ALERT"), Color::Yellow);
+    }
+
+    #[test]
+    fn severity_color_incident_is_cyan() {
+        assert_eq!(severity_color("INCIDENT"), Color::Cyan);
+    }
+
+    #[test]
+    fn severity_color_unknown_is_white() {
+        assert_eq!(severity_color("CRITICAL"), Color::White);
+    }
+
+    #[test]
+    fn severity_color_case_insensitive() {
+        assert_eq!(severity_color("error"), Color::Red);
+        assert_eq!(severity_color("alert"), Color::Yellow);
+        assert_eq!(severity_color("incident"), Color::Cyan);
+    }
+
+    #[test]
+    fn resolve_current_user_env_var_takes_priority() {
+        // SAFETY: test-only; single-threaded test runner for this module.
+        unsafe { std::env::set_var("FORKLAUNCH_USER", "ci-bot") };
+        let user = resolve_current_user("app-123");
+        unsafe { std::env::remove_var("FORKLAUNCH_USER") };
+        assert_eq!(user, "ci-bot");
+    }
+
+    #[test]
+    fn resolve_current_user_trims_whitespace() {
+        // SAFETY: test-only; single-threaded test runner for this module.
+        unsafe { std::env::set_var("FORKLAUNCH_USER", "  alice  ") };
+        let user = resolve_current_user("app-123");
+        unsafe { std::env::remove_var("FORKLAUNCH_USER") };
+        assert_eq!(user, "alice");
+    }
+
+    #[test]
+    fn resolve_current_user_skips_empty_env_var() {
+        // SAFETY: test-only; single-threaded test runner for this module.
+        unsafe { std::env::set_var("FORKLAUNCH_USER", "") };
+        // Don't assert exact value — just verify it doesn't panic and returns non-empty.
+        let user = resolve_current_user("app-123");
+        unsafe { std::env::remove_var("FORKLAUNCH_USER") };
+        assert!(!user.is_empty());
+    }
+
+    #[test]
+    fn issue_deserializes_all_optional_fields() {
+        let json = r#"{
+            "id": "iss-001",
+            "appId": "app-123",
+            "serviceName": "payment-service",
+            "env": "production",
+            "severity": "ERROR",
+            "status": "open",
+            "title": "High error rate",
+            "summary": "Error rate exceeded threshold",
+            "score": 0.95,
+            "firstSeen": "2024-01-15T10:00:00Z",
+            "lastSeen": "2024-01-15T11:00:00Z",
+            "acknowledgedAt": null,
+            "acknowledgedBy": null,
+            "resolvedAt": null,
+            "resolvedBy": null
+        }"#;
+
+        let issue: Issue = serde_json::from_str(json).unwrap();
+        assert_eq!(issue.id, "iss-001");
+        assert_eq!(issue.service_name.as_deref(), Some("payment-service"));
+        assert_eq!(issue.severity.as_deref(), Some("ERROR"));
+        assert_eq!(issue.title.as_deref(), Some("High error rate"));
+        assert_eq!(issue.score, Some(0.95));
+    }
+
+    #[test]
+    fn issue_deserializes_with_only_required_id() {
+        let json = r#"{"id": "iss-002"}"#;
+        let issue: Issue = serde_json::from_str(json).unwrap();
+        assert_eq!(issue.id, "iss-002");
+        assert!(issue.severity.is_none());
+        assert!(issue.service_name.is_none());
+    }
+
+    #[test]
+    fn issues_response_deserializes() {
+        let json = r#"{
+            "issues": [
+                {"id": "iss-001", "severity": "ALERT"},
+                {"id": "iss-002", "severity": "INCIDENT"}
+            ],
+            "total": 2
+        }"#;
+
+        let response: IssuesResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.issues.len(), 2);
+        assert_eq!(response.total, Some(2));
+    }
+
+    #[test]
+    fn ack_response_deserializes_partial() {
+        let json = r#"{"id": "iss-001", "acknowledgedAt": "2024-01-15T10:05:00Z", "acknowledgedBy": "alice"}"#;
+        let response: AckResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.id.as_deref(), Some("iss-001"));
+        assert_eq!(response.acknowledged_by.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn title_truncation_logic() {
+        let long_title = "A".repeat(35);
+        let truncated = if long_title.len() > 30 {
+            format!("{}…", &long_title[..29])
+        } else {
+            long_title.clone()
+        };
+        assert_eq!(truncated.chars().count(), 30); // 29 chars + ellipsis char
+    }
+}

--- a/cli/src/observe/issues.rs
+++ b/cli/src/observe/issues.rs
@@ -33,38 +33,45 @@ impl IssuesCommand {
 
 impl CliCommand for IssuesCommand {
     fn command(&self) -> Command {
-        command("issues", "List or acknowledge active issues for a ForkLaunch application")
-            .arg(
-                Arg::new("base_path")
-                    .short('p')
-                    .long("path")
-                    .help("The application path")
-                    .global(true),
-            )
-            .arg(
-                Arg::new("environment")
-                    .short('e')
-                    .long("environment")
-                    .help("Environment to inspect (for example: dev, staging, production)"),
-            )
-            .arg(
-                Arg::new("severity")
-                    .long("severity")
-                    .help("Filter by severity (ERROR, ALERT, INCIDENT)"),
-            )
-            .arg(
-                Arg::new("status")
-                    .long("status")
-                    .help("Filter by status (for example: open, acknowledged)"),
-            )
-            .arg(
-                Arg::new("json")
-                    .long("json")
-                    .help("Output raw JSON instead of formatted terminal output")
-                    .action(ArgAction::SetTrue)
-                    .global(true),
-            )
-            .subcommand(self.ack.command())
+        command(
+            "issues",
+            "List or acknowledge active issues for a ForkLaunch application",
+        )
+        // Listing requires --environment; the `ack` subcommand doesn't, so
+        // negate the parent requirement when a subcommand is invoked.
+        .subcommand_negates_reqs(true)
+        .arg(
+            Arg::new("base_path")
+                .short('p')
+                .long("path")
+                .help("The application path")
+                .global(true),
+        )
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to inspect (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("severity")
+                .long("severity")
+                .help("Filter by severity (ERROR, ALERT, INCIDENT)"),
+        )
+        .arg(
+            Arg::new("status")
+                .long("status")
+                .help("Filter by status (for example: open, acknowledged)"),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue)
+                .global(true),
+        )
+        .subcommand(self.ack.command())
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
@@ -88,29 +95,17 @@ impl AckCommand {
 
 impl CliCommand for AckCommand {
     fn command(&self) -> Command {
+        // base_path and json are inherited from the parent `issues` command as
+        // global args — no need to redeclare them here.
         command("ack", "Acknowledge an active issue")
-            .arg(
-                Arg::new("base_path")
-                    .short('p')
-                    .long("path")
-                    .help("The application path"),
-            )
             .arg(
                 Arg::new("id")
                     .required(true)
                     .help("The issue ID to acknowledge"),
             )
-            .arg(
-                Arg::new("acknowledged_by")
-                    .long("acknowledged-by")
-                    .help("User acknowledging the issue (defaults to FORKLAUNCH_USER env var, then OS user)"),
-            )
-            .arg(
-                Arg::new("json")
-                    .long("json")
-                    .help("Output raw JSON instead of formatted terminal output")
-                    .action(ArgAction::SetTrue),
-            )
+            .arg(Arg::new("acknowledged_by").long("acknowledged-by").help(
+                "User acknowledging the issue (defaults to FORKLAUNCH_USER env var, then OS user)",
+            ))
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
@@ -131,7 +126,12 @@ fn list_issues(matches: &ArgMatches) -> Result<()> {
     let status = matches.get_one::<String>("status").cloned();
     let json_output = matches.get_flag("json");
 
-    let response = fetch_issues(&application_id, &environment, severity.as_deref(), status.as_deref())?;
+    let response = fetch_issues(
+        &application_id,
+        &environment,
+        severity.as_deref(),
+        status.as_deref(),
+    )?;
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&response)?);
@@ -224,12 +224,16 @@ fn resolve_current_user(_application_id: &str) -> String {
 
 fn post_acknowledge(issue_id: &str, acknowledged_by: &str) -> Result<AckResponse> {
     let api_url = get_observability_api_url();
-    let url = format!("{}/issues/{}/acknowledge", api_url, urlencoding::encode(issue_id));
+    let url = format!(
+        "{}/issues/{}/acknowledge",
+        api_url,
+        urlencoding::encode(issue_id)
+    );
 
     let body = serde_json::json!({ "acknowledgedBy": acknowledged_by });
     let auth_mode = AuthMode::detect();
-    let response =
-        post_with_auth(&auth_mode, &url, body).with_context(|| "Failed to reach observability API")?;
+    let response = post_with_auth(&auth_mode, &url, body)
+        .with_context(|| "Failed to reach observability API")?;
 
     if !response.status().is_success() {
         let http_status = response.status();
@@ -249,6 +253,16 @@ fn post_acknowledge(issue_id: &str, acknowledged_by: &str) -> Result<AckResponse
 fn print_issues(issues: &[Issue]) -> Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
 
+    // Present the feed ranked by score (highest impact first); issues without a
+    // score sort to the bottom.
+    let mut issues: Vec<&Issue> = issues.iter().collect();
+    issues.sort_by(|a, b| {
+        b.score
+            .unwrap_or(f64::MIN)
+            .partial_cmp(&a.score.unwrap_or(f64::MIN))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
     if issues.is_empty() {
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
         writeln!(stdout, "No active issues found.")?;
@@ -262,7 +276,7 @@ fn print_issues(issues: &[Issue]) -> Result<()> {
     stdout.set_color(ColorSpec::new().set_bold(true))?;
     writeln!(
         stdout,
-        "  {:<10}  {:<10}  {:<20}  {:<30}  {}",
+        "  {:<10}  {:<36}  {:<20}  {:<30}  {}",
         "SEVERITY", "ID", "SERVICE", "TITLE", "FIRST SEEN"
     )?;
     stdout.reset()?;
@@ -270,12 +284,12 @@ fn print_issues(issues: &[Issue]) -> Result<()> {
     stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
     writeln!(
         stdout,
-        "  {:-<10}  {:-<10}  {:-<20}  {:-<30}  {:-<19}",
+        "  {:-<10}  {:-<36}  {:-<20}  {:-<30}  {:-<19}",
         "", "", "", "", ""
     )?;
     stdout.reset()?;
 
-    for issue in issues {
+    for issue in &issues {
         let severity = issue.severity.as_deref().unwrap_or("UNKNOWN");
         let color = severity_color(severity);
 
@@ -283,7 +297,8 @@ fn print_issues(issues: &[Issue]) -> Result<()> {
         write!(stdout, "  {:<10}", severity)?;
         stdout.reset()?;
 
-        let id_display = issue.id.get(..10).unwrap_or(&issue.id);
+        // Show the full id — it's needed verbatim for `observe issues ack <id>`.
+        let id_display = issue.id.as_str();
         let service = issue.service_name.as_deref().unwrap_or("-");
         let title = issue.title.as_deref().unwrap_or("-");
         let title_truncated = if title.chars().count() > 30 {
@@ -300,7 +315,7 @@ fn print_issues(issues: &[Issue]) -> Result<()> {
 
         writeln!(
             stdout,
-            "  {:<10}  {:<20}  {:<30}  {}",
+            "  {:<36}  {:<20}  {:<30}  {}",
             id_display, service, title_truncated, first_seen
         )?;
     }
@@ -398,6 +413,40 @@ struct AckResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The real CLI attaches a version at the root app; add one here so clap's
+    // standalone checks don't trip on missing version propagation.
+    fn issues_cmd() -> Command {
+        IssuesCommand::new().command().version("0.0.0-test")
+    }
+
+    #[test]
+    fn command_definition_is_valid() {
+        // Catches clap misconfiguration (e.g. required arg + global + negates_reqs).
+        issues_cmd().debug_assert();
+    }
+
+    #[test]
+    fn list_requires_environment() {
+        // No --environment and no subcommand → parse error.
+        assert!(issues_cmd().try_get_matches_from(["issues"]).is_err());
+        // With --environment → ok.
+        assert!(
+            issues_cmd()
+                .try_get_matches_from(["issues", "-e", "dev"])
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn ack_does_not_require_environment() {
+        // ack subcommand negates the parent's --environment requirement.
+        assert!(
+            issues_cmd()
+                .try_get_matches_from(["issues", "ack", "issue-123"])
+                .is_ok()
+        );
+    }
 
     #[test]
     fn severity_color_error_is_red() {

--- a/cli/src/observe/issues.rs
+++ b/cli/src/observe/issues.rs
@@ -38,7 +38,8 @@ impl CliCommand for IssuesCommand {
                 Arg::new("base_path")
                     .short('p')
                     .long("path")
-                    .help("The application path"),
+                    .help("The application path")
+                    .global(true),
             )
             .arg(
                 Arg::new("environment")
@@ -60,7 +61,8 @@ impl CliCommand for IssuesCommand {
                 Arg::new("json")
                     .long("json")
                     .help("Output raw JSON instead of formatted terminal output")
-                    .action(ArgAction::SetTrue),
+                    .action(ArgAction::SetTrue)
+                    .global(true),
             )
             .subcommand(self.ack.command())
     }
@@ -101,7 +103,7 @@ impl CliCommand for AckCommand {
             .arg(
                 Arg::new("acknowledged_by")
                     .long("acknowledged-by")
-                    .help("User acknowledging the issue (defaults to the logged-in user's email)"),
+                    .help("User acknowledging the issue (defaults to FORKLAUNCH_USER env var, then OS user)"),
             )
             .arg(
                 Arg::new("json")
@@ -284,8 +286,8 @@ fn print_issues(issues: &[Issue]) -> Result<()> {
         let id_display = issue.id.get(..10).unwrap_or(&issue.id);
         let service = issue.service_name.as_deref().unwrap_or("-");
         let title = issue.title.as_deref().unwrap_or("-");
-        let title_truncated = if title.len() > 30 {
-            format!("{}…", &title[..29])
+        let title_truncated = if title.chars().count() > 30 {
+            format!("{}…", title.chars().take(29).collect::<String>())
         } else {
             title.to_string()
         };
@@ -424,32 +426,41 @@ mod tests {
         assert_eq!(severity_color("incident"), Color::Cyan);
     }
 
+    fn with_forklaunch_user<F: FnOnce()>(value: &str, f: F) {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("FORKLAUNCH_USER").ok();
+        // SAFETY: serialized by ENV_LOCK; no other test mutates FORKLAUNCH_USER concurrently.
+        unsafe { std::env::set_var("FORKLAUNCH_USER", value) };
+        f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("FORKLAUNCH_USER", v),
+                None => std::env::remove_var("FORKLAUNCH_USER"),
+            }
+        }
+    }
+
     #[test]
     fn resolve_current_user_env_var_takes_priority() {
-        // SAFETY: test-only; single-threaded test runner for this module.
-        unsafe { std::env::set_var("FORKLAUNCH_USER", "ci-bot") };
-        let user = resolve_current_user("app-123");
-        unsafe { std::env::remove_var("FORKLAUNCH_USER") };
-        assert_eq!(user, "ci-bot");
+        with_forklaunch_user("ci-bot", || {
+            assert_eq!(resolve_current_user("app-123"), "ci-bot");
+        });
     }
 
     #[test]
     fn resolve_current_user_trims_whitespace() {
-        // SAFETY: test-only; single-threaded test runner for this module.
-        unsafe { std::env::set_var("FORKLAUNCH_USER", "  alice  ") };
-        let user = resolve_current_user("app-123");
-        unsafe { std::env::remove_var("FORKLAUNCH_USER") };
-        assert_eq!(user, "alice");
+        with_forklaunch_user("  alice  ", || {
+            assert_eq!(resolve_current_user("app-123"), "alice");
+        });
     }
 
     #[test]
     fn resolve_current_user_skips_empty_env_var() {
-        // SAFETY: test-only; single-threaded test runner for this module.
-        unsafe { std::env::set_var("FORKLAUNCH_USER", "") };
-        // Don't assert exact value — just verify it doesn't panic and returns non-empty.
-        let user = resolve_current_user("app-123");
-        unsafe { std::env::remove_var("FORKLAUNCH_USER") };
-        assert!(!user.is_empty());
+        with_forklaunch_user("", || {
+            assert!(!resolve_current_user("app-123").is_empty());
+        });
     }
 
     #[test]
@@ -515,11 +526,22 @@ mod tests {
     #[test]
     fn title_truncation_logic() {
         let long_title = "A".repeat(35);
-        let truncated = if long_title.len() > 30 {
-            format!("{}…", &long_title[..29])
+        let truncated = if long_title.chars().count() > 30 {
+            format!("{}…", long_title.chars().take(29).collect::<String>())
         } else {
             long_title.clone()
         };
-        assert_eq!(truncated.chars().count(), 30); // 29 chars + ellipsis char
+        assert_eq!(truncated.chars().count(), 30);
+    }
+
+    #[test]
+    fn title_truncation_handles_multibyte_chars() {
+        let long_title = "é".repeat(35);
+        let truncated = if long_title.chars().count() > 30 {
+            format!("{}…", long_title.chars().take(29).collect::<String>())
+        } else {
+            long_title.clone()
+        };
+        assert_eq!(truncated.chars().count(), 30);
     }
 }

--- a/cli/src/observe/mod.rs
+++ b/cli/src/observe/mod.rs
@@ -3,9 +3,11 @@ use clap::{ArgMatches, Command};
 
 use crate::{CliCommand, core::command::command};
 
+mod issues;
 mod logs;
 mod status;
 
+use issues::IssuesCommand;
 use logs::LogsCommand;
 use status::StatusCommand;
 
@@ -13,6 +15,7 @@ use status::StatusCommand;
 pub(crate) struct ObserveCommand {
     status: StatusCommand,
     logs: LogsCommand,
+    issues: IssuesCommand,
 }
 
 impl ObserveCommand {
@@ -20,6 +23,7 @@ impl ObserveCommand {
         Self {
             status: StatusCommand::new(),
             logs: LogsCommand::new(),
+            issues: IssuesCommand::new(),
         }
     }
 }
@@ -32,6 +36,7 @@ impl CliCommand for ObserveCommand {
         )
         .subcommand(self.status.command())
         .subcommand(self.logs.command())
+        .subcommand(self.issues.command())
         .subcommand_required(true)
     }
 
@@ -39,6 +44,7 @@ impl CliCommand for ObserveCommand {
         match matches.subcommand() {
             Some(("status", sub_matches)) => self.status.handler(sub_matches),
             Some(("logs", sub_matches)) => self.logs.handler(sub_matches),
+            Some(("issues", sub_matches)) => self.issues.handler(sub_matches),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
## Summary
- Adds `forklaunch observe issues -e <env>` — fetches active issues from the observability API and renders a ranked color-coded table (ERROR=red, ALERT=yellow, INCIDENT=cyan)
- Adds `forklaunch observe issues ack <id> [--acknowledged-by <user>]` — POSTs to `/issues/{id}/acknowledge`; defaults `acknowledgedBy` to the OS user or `FORKLAUNCH_USER` env var
- Both modes support `--json` for raw JSON output
- Follows the exact clap/AuthMode/termcolor/serde patterns of `observe logs` and `observe status`

Closes FOR-97
Closes https://linear.app/forklaunch/issue/FOR-97/observability-obs-14-observe-issues

## Test plan
- [ ] `cargo test observe::issues` — 13 unit tests pass
- [ ] `cargo test` — 290/290 pass, no regressions
- [ ] Manual: `forklaunch observe issues -e staging` against a seeded env
- [ ] Manual: `forklaunch observe issues ack <id>` with and without `--acknowledged-by`
- [ ] Manual: `--json` flag on both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `issues` command to the CLI for managing active observability issues from your applications.
  * List all issues with flexible filtering options for application, environment, severity level, and status.
  * Acknowledge individual issues with automatic or manually specified user attribution.
  * Both list and acknowledge operations support formatted terminal output and JSON output for programmatic use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->