### PR TITLE
feat(cli): FOR-96 OBS-13 observe metrics and observe traces

### DIFF
--- a/cli/src/observe/metrics.rs
+++ b/cli/src/observe/metrics.rs
@@ -1,0 +1,459 @@
+use std::{collections::HashMap, io::Write};
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::get_observability_api_url,
+    core::{
+        command::command,
+        hmac::AuthMode,
+        http_client::{get_with_auth, post_with_auth},
+        validate::{require_integration, require_manifest},
+    },
+};
+
+// ── Top-level command ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub(super) struct MetricsCommand;
+
+impl MetricsCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for MetricsCommand {
+    fn command(&self) -> Command {
+        command("metrics", "Query metrics for a ForkLaunch application")
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
+            )
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .required(true)
+                    .help("Environment to inspect (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("app_id")
+                    .long("app-id")
+                    .help("Application ID (defaults to value from forklaunch.json)"),
+            )
+            .arg(
+                Arg::new("time_range")
+                    .long("time-range")
+                    .default_value("1h")
+                    .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
+                    .help("Time range for metrics (15m, 1h, 6h, 24h, 7d, 30d)"),
+            )
+            .arg(
+                Arg::new("query")
+                    .long("query")
+                    .help("Raw PromQL query string"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let environment = matches
+            .get_one::<String>("environment")
+            .context("--environment is required")?
+            .to_string();
+        let time_range = matches
+            .get_one::<String>("time_range")
+            .cloned()
+            .unwrap_or_else(|| "1h".to_string());
+        let query = matches.get_one::<String>("query").cloned();
+        let json_output = matches.get_flag("json");
+
+        // Resolve application_id: prefer --app-id flag, fall back to manifest
+        let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
+            id
+        } else {
+            let (_app_root, manifest) = require_manifest(matches)?;
+            require_integration(&manifest)?
+        };
+
+        if let Some(q) = query {
+            let response =
+                fetch_promql(&q, &environment, &application_id, &time_range)?;
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_promql(&response)?;
+            }
+        } else {
+            let response =
+                fetch_application_metrics(&application_id, &environment, &time_range)?;
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_metrics(&response)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+fn fetch_application_metrics(
+    application_id: &str,
+    environment: &str,
+    time_range: &str,
+) -> Result<ApplicationMonitoringResponse> {
+    let api_url = get_observability_api_url();
+    let url = format!(
+        "{}/applications/{}/monitoring?environment={}&timeRange={}",
+        api_url,
+        urlencoding::encode(application_id),
+        urlencoding::encode(environment),
+        urlencoding::encode(time_range),
+    );
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse metrics response")
+}
+
+fn fetch_promql(
+    query: &str,
+    environment: &str,
+    application_id: &str,
+    time_range: &str,
+) -> Result<PromQLResponse> {
+    let api_url = get_observability_api_url();
+    let url = format!("{}/monitoring/promql", api_url);
+
+    let body = serde_json::json!({
+        "query": query,
+        "environment": environment,
+        "applicationId": application_id,
+        "timeRange": time_range,
+    });
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        post_with_auth(&auth_mode, &url, body).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse PromQL response")
+}
+
+// ── Display ───────────────────────────────────────────────────────────────────
+
+fn print_metrics(response: &ApplicationMonitoringResponse) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+    writeln!(stdout, "  Application Metrics")?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    // Header
+    stdout.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(stdout, "  {:<25}  {:<15}  {}", "METRIC", "VALUE", "UNIT")?;
+    stdout.reset()?;
+
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(stdout, "  {:-<25}  {:-<15}  {:-<10}", "", "", "")?;
+    stdout.reset()?;
+
+    print_metric_row(&mut stdout, "Request Rate", &response.request_rate)?;
+    print_metric_row(&mut stdout, "Error Rate", &response.error_rate)?;
+
+    if let Some(latency) = &response.latency {
+        if let Some(p50) = latency.p50 {
+            print_metric_row(
+                &mut stdout,
+                "Latency p50",
+                &MetricValue {
+                    value: Some(p50),
+                    unit: latency.unit.clone(),
+                    available: latency.available,
+                },
+            )?;
+        }
+        if let Some(p95) = latency.p95 {
+            print_metric_row(
+                &mut stdout,
+                "Latency p95",
+                &MetricValue {
+                    value: Some(p95),
+                    unit: latency.unit.clone(),
+                    available: latency.available,
+                },
+            )?;
+        }
+        if let Some(p99) = latency.p99 {
+            print_metric_row(
+                &mut stdout,
+                "Latency p99",
+                &MetricValue {
+                    value: Some(p99),
+                    unit: latency.unit.clone(),
+                    available: latency.available,
+                },
+            )?;
+        }
+    }
+
+    print_metric_row(&mut stdout, "Uptime", &response.uptime)?;
+
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn print_metric_row(out: &mut StandardStream, name: &str, metric: &MetricValue) -> Result<()> {
+    let available = metric.available.unwrap_or(true);
+    let value_str = if available {
+        metric
+            .value
+            .map(|v| format!("{:.4}", v))
+            .unwrap_or_else(|| "-".to_string())
+    } else {
+        "unavailable".to_string()
+    };
+    let unit_str = metric.unit.as_deref().unwrap_or("-");
+
+    if !available {
+        out.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    }
+    writeln!(out, "  {:<25}  {:<15}  {}", name, value_str, unit_str)?;
+    out.reset()?;
+
+    Ok(())
+}
+
+fn print_promql(response: &PromQLResponse) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+    writeln!(stdout, "  PromQL Results  ({})", response.data.result_type)?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    if response.data.result.is_empty() {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        writeln!(stdout, "  No results.")?;
+        stdout.reset()?;
+    } else {
+        for (i, series) in response.data.result.iter().enumerate() {
+            stdout.set_color(ColorSpec::new().set_bold(true))?;
+            write!(stdout, "  [{i}]")?;
+            stdout.reset()?;
+
+            // Print labels
+            if !series.metric.is_empty() {
+                let labels: Vec<String> = series
+                    .metric
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v:?}"))
+                    .collect();
+                writeln!(stdout, "  {{{}}}", labels.join(", "))?;
+            } else {
+                writeln!(stdout, "  {{<no labels>}}")?;
+            }
+
+            // Value tuple: [timestamp_f64, value_string]
+            if series.value.len() == 2 {
+                writeln!(stdout, "       value: {}", series.value[1])?;
+            }
+        }
+    }
+
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MetricValue {
+    #[serde(default)]
+    value: Option<f64>,
+    #[serde(default)]
+    unit: Option<String>,
+    #[serde(default)]
+    available: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LatencyMetric {
+    #[serde(default)]
+    p50: Option<f64>,
+    #[serde(default)]
+    p95: Option<f64>,
+    #[serde(default)]
+    p99: Option<f64>,
+    #[serde(default)]
+    unit: Option<String>,
+    #[serde(default)]
+    available: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationMonitoringResponse {
+    #[serde(default)]
+    request_rate: MetricValue,
+    #[serde(default)]
+    error_rate: MetricValue,
+    #[serde(default)]
+    latency: Option<LatencyMetric>,
+    #[serde(default)]
+    uptime: MetricValue,
+}
+
+impl Default for MetricValue {
+    fn default() -> Self {
+        Self {
+            value: None,
+            unit: None,
+            available: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PromQLResultEntry {
+    #[serde(default)]
+    metric: HashMap<String, String>,
+    #[serde(default)]
+    value: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PromQLData {
+    result_type: String,
+    result: Vec<PromQLResultEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PromQLResponse {
+    status: String,
+    data: PromQLData,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_value_deserializes_all_fields() {
+        let json = r#"{"value": 12.5, "unit": "req/s", "available": true}"#;
+        let mv: MetricValue = serde_json::from_str(json).unwrap();
+        assert_eq!(mv.value, Some(12.5));
+        assert_eq!(mv.unit.as_deref(), Some("req/s"));
+        assert_eq!(mv.available, Some(true));
+    }
+
+    #[test]
+    fn metric_value_defaults_when_absent() {
+        let mv: MetricValue = serde_json::from_str("{}").unwrap();
+        assert!(mv.value.is_none());
+        assert!(mv.unit.is_none());
+        assert!(mv.available.is_none());
+    }
+
+    #[test]
+    fn latency_metric_deserializes() {
+        let json = r#"{"p50": 10.0, "p95": 50.0, "p99": 100.0, "unit": "ms", "available": true}"#;
+        let lm: LatencyMetric = serde_json::from_str(json).unwrap();
+        assert_eq!(lm.p50, Some(10.0));
+        assert_eq!(lm.p95, Some(50.0));
+        assert_eq!(lm.p99, Some(100.0));
+        assert_eq!(lm.unit.as_deref(), Some("ms"));
+    }
+
+    #[test]
+    fn promql_response_deserializes() {
+        let json = r#"{
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {
+                        "metric": {"__name__": "http_requests_total", "job": "api"},
+                        "value": [1700000000.0, "42"]
+                    }
+                ]
+            }
+        }"#;
+        let resp: PromQLResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "success");
+        assert_eq!(resp.data.result_type, "vector");
+        assert_eq!(resp.data.result.len(), 1);
+        assert_eq!(
+            resp.data.result[0].metric.get("job").map(|s| s.as_str()),
+            Some("api")
+        );
+    }
+
+    #[test]
+    fn promql_response_empty_result() {
+        let json = r#"{"status": "success", "data": {"resultType": "vector", "result": []}}"#;
+        let resp: PromQLResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.data.result.is_empty());
+    }
+
+    #[test]
+    fn application_monitoring_response_deserializes() {
+        let json = r#"{
+            "requestRate": {"value": 10.0, "unit": "req/s", "available": true},
+            "errorRate": {"value": 0.5, "unit": "%", "available": true},
+            "latency": {"p50": 10.0, "p95": 50.0, "p99": 100.0, "unit": "ms", "available": true},
+            "uptime": {"value": 99.9, "unit": "%", "available": true}
+        }"#;
+        let resp: ApplicationMonitoringResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.request_rate.value, Some(10.0));
+        assert!(resp.latency.is_some());
+    }
+}

--- a/cli/src/observe/metrics.rs
+++ b/cli/src/observe/metrics.rs
@@ -46,7 +46,7 @@ impl CliCommand for MetricsCommand {
             .arg(
                 Arg::new("app_id")
                     .long("app-id")
-                    .help("Application ID (defaults to value from forklaunch.json)"),
+                    .help("Application ID (defaults to value from .forklaunch/manifest.toml)"),
             )
             .arg(
                 Arg::new("time_range")

--- a/cli/src/observe/mod.rs
+++ b/cli/src/observe/mod.rs
@@ -4,15 +4,21 @@ use clap::{ArgMatches, Command};
 use crate::{CliCommand, core::command::command};
 
 mod logs;
+mod metrics;
 mod status;
+mod traces;
 
 use logs::LogsCommand;
+use metrics::MetricsCommand;
 use status::StatusCommand;
+use traces::TracesCommand;
 
 #[derive(Debug)]
 pub(crate) struct ObserveCommand {
     status: StatusCommand,
     logs: LogsCommand,
+    metrics: MetricsCommand,
+    traces: TracesCommand,
 }
 
 impl ObserveCommand {
@@ -20,6 +26,8 @@ impl ObserveCommand {
         Self {
             status: StatusCommand::new(),
             logs: LogsCommand::new(),
+            metrics: MetricsCommand::new(),
+            traces: TracesCommand::new(),
         }
     }
 }
@@ -32,6 +40,8 @@ impl CliCommand for ObserveCommand {
         )
         .subcommand(self.status.command())
         .subcommand(self.logs.command())
+        .subcommand(self.metrics.command())
+        .subcommand(self.traces.command())
         .subcommand_required(true)
     }
 
@@ -39,6 +49,8 @@ impl CliCommand for ObserveCommand {
         match matches.subcommand() {
             Some(("status", sub_matches)) => self.status.handler(sub_matches),
             Some(("logs", sub_matches)) => self.logs.handler(sub_matches),
+            Some(("metrics", sub_matches)) => self.metrics.handler(sub_matches),
+            Some(("traces", sub_matches)) => self.traces.handler(sub_matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -281,7 +281,8 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         let is_error = span
             .attributes
             .get("otel.status_code")
-            .map(|v| v.as_str() == "ERROR")
+            .and_then(|v| v.as_str())
+            .map(|s| s == "ERROR")
             .unwrap_or(false);
         let color = if is_error {
             Color::Red

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -30,150 +30,90 @@ impl TracesCommand {
 impl CliCommand for TracesCommand {
     fn command(&self) -> Command {
         command("traces", "Query distributed traces for a ForkLaunch application")
-            .subcommand_required(true)
-            .subcommand(
-                command("recent", "List recent traces for an application")
-                    .arg(
-                        Arg::new("base_path")
-                            .short('p')
-                            .long("path")
-                            .help("The application path"),
-                    )
-                    .arg(
-                        Arg::new("environment")
-                            .short('e')
-                            .long("environment")
-                            .required(true)
-                            .help("Environment to inspect (for example: dev, staging, production)"),
-                    )
-                    .arg(
-                        Arg::new("app_id")
-                            .long("app-id")
-                            .help("Application ID (defaults to value from forklaunch.json)"),
-                    )
-                    .arg(
-                        Arg::new("limit")
-                            .long("limit")
-                            .default_value("50")
-                            .help("Maximum number of traces to fetch"),
-                    )
-                    .arg(
-                        Arg::new("time_range")
-                            .long("time-range")
-                            .default_value("1h")
-                            .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
-                            .help("Time range for traces (15m, 1h, 6h, 24h, 7d, 30d)"),
-                    )
-                    .arg(
-                        Arg::new("json")
-                            .long("json")
-                            .help("Output raw JSON instead of formatted terminal output")
-                            .action(ArgAction::SetTrue),
-                    ),
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
             )
-            .subcommand(
-                command("show", "Drill into a single trace and display its span tree")
-                    .arg(
-                        Arg::new("base_path")
-                            .short('p')
-                            .long("path")
-                            .help("The application path"),
-                    )
-                    .arg(
-                        Arg::new("environment")
-                            .short('e')
-                            .long("environment")
-                            .required(true)
-                            .help("Environment to inspect (for example: dev, staging, production)"),
-                    )
-                    .arg(
-                        Arg::new("app_id")
-                            .long("app-id")
-                            .help("Application ID (defaults to value from forklaunch.json)"),
-                    )
-                    .arg(
-                        Arg::new("trace_id")
-                            .required(true)
-                            .help("Trace ID to inspect"),
-                    )
-                    .arg(
-                        Arg::new("json")
-                            .long("json")
-                            .help("Output raw JSON instead of formatted terminal output")
-                            .action(ArgAction::SetTrue),
-                    ),
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .required(true)
+                    .help("Environment to inspect (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("app_id")
+                    .long("app-id")
+                    .help("Application ID (defaults to value from forklaunch.json)"),
+            )
+            .arg(
+                Arg::new("trace_id")
+                    .long("trace-id")
+                    .help("Trace ID — show full span tree for a single trace"),
+            )
+            .arg(
+                Arg::new("limit")
+                    .long("limit")
+                    .default_value("50")
+                    .help("Maximum number of traces to fetch (list mode only)"),
+            )
+            .arg(
+                Arg::new("time_range")
+                    .long("time-range")
+                    .default_value("1h")
+                    .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
+                    .help("Time range for traces (list mode only): 15m, 1h, 6h, 24h, 7d, 30d"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
             )
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
-        match matches.subcommand() {
-            Some(("recent", sub)) => handle_recent(sub),
-            Some(("show", sub)) => handle_show(sub),
-            _ => unreachable!("subcommand_required enforces a match"),
+        let environment = matches
+            .get_one::<String>("environment")
+            .context("--environment is required")?
+            .to_string();
+        let json_output = matches.get_flag("json");
+
+        let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
+            id
+        } else {
+            let (_app_root, manifest) = require_manifest(matches)?;
+            require_integration(&manifest)?
+        };
+
+        if let Some(trace_id) = matches.get_one::<String>("trace_id").cloned() {
+            let response = fetch_trace_detail(&application_id, &environment, &trace_id)?;
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_trace_detail(&response)?;
+            }
+        } else {
+            let limit = matches
+                .get_one::<String>("limit")
+                .cloned()
+                .unwrap_or_else(|| "50".to_string());
+            let time_range = matches
+                .get_one::<String>("time_range")
+                .cloned()
+                .unwrap_or_else(|| "1h".to_string());
+            let response = fetch_traces(&application_id, &environment, &limit, &time_range)?;
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_traces(&response.traces)?;
+            }
         }
+
+        Ok(())
     }
-}
-
-// ── Subcommand handlers ───────────────────────────────────────────────────────
-
-fn handle_recent(matches: &ArgMatches) -> Result<()> {
-    let environment = matches
-        .get_one::<String>("environment")
-        .context("--environment is required")?
-        .to_string();
-    let time_range = matches
-        .get_one::<String>("time_range")
-        .cloned()
-        .unwrap_or_else(|| "1h".to_string());
-    let limit = matches
-        .get_one::<String>("limit")
-        .cloned()
-        .unwrap_or_else(|| "50".to_string());
-    let json_output = matches.get_flag("json");
-
-    let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
-        id
-    } else {
-        let (_app_root, manifest) = require_manifest(matches)?;
-        require_integration(&manifest)?
-    };
-
-    let response = fetch_traces(&application_id, &environment, &limit, &time_range)?;
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&response)?);
-    } else {
-        print_traces(&response.traces)?;
-    }
-
-    Ok(())
-}
-
-fn handle_show(matches: &ArgMatches) -> Result<()> {
-    let environment = matches
-        .get_one::<String>("environment")
-        .context("--environment is required")?
-        .to_string();
-    let trace_id = matches
-        .get_one::<String>("trace_id")
-        .context("trace ID is required")?
-        .to_string();
-    let json_output = matches.get_flag("json");
-
-    let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
-        id
-    } else {
-        let (_app_root, manifest) = require_manifest(matches)?;
-        require_integration(&manifest)?
-    };
-
-    let response = fetch_trace_detail(&application_id, &environment, &trace_id)?;
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&response)?);
-    } else {
-        print_trace_detail(&response)?;
-    }
-
-    Ok(())
 }
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
@@ -257,7 +197,6 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
         return Ok(());
     }
 
-    // Header
     stdout.set_color(ColorSpec::new().set_bold(true))?;
     writeln!(
         stdout,

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -326,7 +326,7 @@ fn build_depth_map(spans: &[Span]) -> HashMap<String, usize> {
     }
 
     let mut depth_map: HashMap<String, usize> = HashMap::new();
-    // BFS from roots (parent_span_id == None)
+    // DFS from roots (parent_span_id == None)
     let mut queue: Vec<(&Span, usize)> = children
         .get(&None)
         .map(|roots| roots.iter().map(|s| (*s, 0usize)).collect())

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -1,0 +1,512 @@
+use std::{collections::HashMap, io::Write};
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::get_observability_api_url,
+    core::{
+        command::command,
+        hmac::AuthMode,
+        http_client::get_with_auth,
+        validate::{require_integration, require_manifest},
+    },
+};
+
+// ── Top-level command ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub(super) struct TracesCommand;
+
+impl TracesCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for TracesCommand {
+    fn command(&self) -> Command {
+        command("traces", "Query distributed traces for a ForkLaunch application")
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
+            )
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .required(true)
+                    .help("Environment to inspect (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("app_id")
+                    .long("app-id")
+                    .help("Application ID (defaults to value from forklaunch.json)"),
+            )
+            .arg(
+                Arg::new("id")
+                    .long("id")
+                    .help("Trace ID — triggers detail mode for a single trace"),
+            )
+            .arg(
+                Arg::new("limit")
+                    .long("limit")
+                    .default_value("50")
+                    .help("Maximum number of traces to fetch"),
+            )
+            .arg(
+                Arg::new("time_range")
+                    .long("time-range")
+                    .default_value("1h")
+                    .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
+                    .help("Time range for traces (15m, 1h, 6h, 24h, 7d, 30d)"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let environment = matches
+            .get_one::<String>("environment")
+            .context("--environment is required")?
+            .to_string();
+        let time_range = matches
+            .get_one::<String>("time_range")
+            .cloned()
+            .unwrap_or_else(|| "1h".to_string());
+        let limit = matches
+            .get_one::<String>("limit")
+            .cloned()
+            .unwrap_or_else(|| "50".to_string());
+        let trace_id = matches.get_one::<String>("id").cloned();
+        let json_output = matches.get_flag("json");
+
+        // Resolve application_id: prefer --app-id flag, fall back to manifest
+        let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
+            id
+        } else {
+            let (_app_root, manifest) = require_manifest(matches)?;
+            require_integration(&manifest)?
+        };
+
+        if let Some(tid) = trace_id {
+            let response = fetch_trace_detail(&application_id, &environment, &tid)?;
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_trace_detail(&response)?;
+            }
+        } else {
+            let response =
+                fetch_traces(&application_id, &environment, &limit, &time_range)?;
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else {
+                print_traces(&response.traces)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+fn fetch_traces(
+    application_id: &str,
+    environment: &str,
+    limit: &str,
+    time_range: &str,
+) -> Result<TraceListResponse> {
+    let api_url = get_observability_api_url();
+    let url = format!(
+        "{}/applications/{}/traces?environment={}&limit={}&timeRange={}",
+        api_url,
+        urlencoding::encode(application_id),
+        urlencoding::encode(environment),
+        urlencoding::encode(limit),
+        urlencoding::encode(time_range),
+    );
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse traces response")
+}
+
+fn fetch_trace_detail(
+    application_id: &str,
+    environment: &str,
+    trace_id: &str,
+) -> Result<TraceDetailResponse> {
+    let api_url = get_observability_api_url();
+    let url = format!(
+        "{}/applications/{}/traces/{}?environment={}",
+        api_url,
+        urlencoding::encode(application_id),
+        urlencoding::encode(trace_id),
+        urlencoding::encode(environment),
+    );
+
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach observability API")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Observability API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse trace detail response")
+}
+
+// ── Display ───────────────────────────────────────────────────────────────────
+
+fn print_traces(traces: &[TraceEntry]) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    writeln!(stdout)?;
+
+    if traces.is_empty() {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        writeln!(stdout, "  No traces found.")?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+        return Ok(());
+    }
+
+    // Header
+    stdout.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(
+        stdout,
+        "  {:<14}  {:<20}  {:<30}  {:<10}  {:<10}  {}",
+        "TRACE ID", "SERVICE", "ROUTE", "DURATION", "STATUS", "START TIME"
+    )?;
+    stdout.reset()?;
+
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(
+        stdout,
+        "  {:-<14}  {:-<20}  {:-<30}  {:-<10}  {:-<10}  {:-<19}",
+        "", "", "", "", "", ""
+    )?;
+    stdout.reset()?;
+
+    for trace in traces {
+        let trace_id_short = trace.trace_id.get(..12).unwrap_or(&trace.trace_id);
+        let service = if trace.service_name.chars().count() > 20 {
+            format!("{}…", trace.service_name.chars().take(19).collect::<String>())
+        } else {
+            trace.service_name.clone()
+        };
+        let route = if trace.route.chars().count() > 30 {
+            format!("{}…", trace.route.chars().take(29).collect::<String>())
+        } else {
+            trace.route.clone()
+        };
+        let duration = format!("{}ms", trace.duration_ms);
+        let start_time = trace
+            .start_time
+            .get(..19)
+            .map(|s| s.replace('T', " "))
+            .unwrap_or_else(|| trace.start_time.clone());
+
+        let color = status_color(&trace.status);
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        write!(stdout, "  {:<14}  {:<20}  {:<30}  {:<10}  ", trace_id_short, service, route, duration)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(stdout, "{:<10}", trace.status)?;
+        stdout.reset()?;
+        writeln!(stdout, "  {}", start_time)?;
+    }
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(stdout, "  {} trace(s) found.", traces.len())?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+    writeln!(stdout, "  Trace {}", response.trace_id)?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    if response.spans.is_empty() {
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        writeln!(stdout, "  No spans found.")?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+        return Ok(());
+    }
+
+    // Build parent -> children map for indentation
+    let depth_map = build_depth_map(&response.spans);
+
+    for span in &response.spans {
+        let depth = depth_map.get(&span.span_id).copied().unwrap_or(0);
+        let indent = "  ".repeat(depth + 1); // base 1-level indent for all spans
+
+        let color = if span.duration_ms > 1000 {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
+
+        stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(stdout, "{}{}", indent, span.name)?;
+        stdout.reset()?;
+
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        writeln!(
+            stdout,
+            "  ({}, {}ms)",
+            span.service_name, span.duration_ms
+        )?;
+        stdout.reset()?;
+    }
+
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+    writeln!(stdout, "  {} span(s).", response.spans.len())?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+/// Returns a map from spanId -> depth (root = 0).
+fn build_depth_map(spans: &[Span]) -> HashMap<String, usize> {
+    // Build parent -> children adjacency
+    let mut children: HashMap<Option<String>, Vec<&Span>> = HashMap::new();
+    for span in spans {
+        children
+            .entry(span.parent_span_id.clone())
+            .or_default()
+            .push(span);
+    }
+
+    let mut depth_map: HashMap<String, usize> = HashMap::new();
+    // BFS from roots (parent_span_id == None)
+    let mut queue: Vec<(&Span, usize)> = children
+        .get(&None)
+        .map(|roots| roots.iter().map(|s| (*s, 0usize)).collect())
+        .unwrap_or_default();
+
+    while let Some((span, depth)) = queue.pop() {
+        depth_map.insert(span.span_id.clone(), depth);
+        if let Some(kids) = children.get(&Some(span.span_id.clone())) {
+            for kid in kids {
+                queue.push((kid, depth + 1));
+            }
+        }
+    }
+
+    depth_map
+}
+
+fn status_color(status: &str) -> Color {
+    match status.to_lowercase().as_str() {
+        "ok" | "success" | "200" => Color::Green,
+        "error" | "500" | "503" => Color::Red,
+        s if s.starts_with('4') => Color::Yellow,
+        s if s.starts_with('5') => Color::Red,
+        _ => Color::White,
+    }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TraceEntry {
+    trace_id: String,
+    service_name: String,
+    route: String,
+    duration_ms: u64,
+    status: String,
+    start_time: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TraceListResponse {
+    traces: Vec<TraceEntry>,
+    #[serde(default)]
+    available: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Span {
+    span_id: String,
+    #[serde(default)]
+    parent_span_id: Option<String>,
+    name: String,
+    service_name: String,
+    start_time: String,
+    duration_ms: u64,
+    #[serde(default)]
+    attributes: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TraceDetailResponse {
+    trace_id: String,
+    spans: Vec<Span>,
+    #[serde(default)]
+    available: bool,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_span(span_id: &str, parent_span_id: Option<&str>, name: &str) -> Span {
+        Span {
+            span_id: span_id.to_string(),
+            parent_span_id: parent_span_id.map(|s| s.to_string()),
+            name: name.to_string(),
+            service_name: "svc".to_string(),
+            start_time: "2024-01-15T10:00:00Z".to_string(),
+            duration_ms: 100,
+            attributes: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn status_color_ok_is_green() {
+        assert_eq!(status_color("ok"), Color::Green);
+        assert_eq!(status_color("success"), Color::Green);
+    }
+
+    #[test]
+    fn status_color_error_is_red() {
+        assert_eq!(status_color("error"), Color::Red);
+        assert_eq!(status_color("500"), Color::Red);
+    }
+
+    #[test]
+    fn status_color_4xx_is_yellow() {
+        assert_eq!(status_color("404"), Color::Yellow);
+    }
+
+    #[test]
+    fn build_depth_map_root_is_zero() {
+        let spans = vec![make_span("root", None, "root-op")];
+        let map = build_depth_map(&spans);
+        assert_eq!(map["root"], 0);
+    }
+
+    #[test]
+    fn build_depth_map_child_is_one() {
+        let spans = vec![
+            make_span("root", None, "root-op"),
+            make_span("child", Some("root"), "child-op"),
+        ];
+        let map = build_depth_map(&spans);
+        assert_eq!(map["root"], 0);
+        assert_eq!(map["child"], 1);
+    }
+
+    #[test]
+    fn build_depth_map_grandchild_is_two() {
+        let spans = vec![
+            make_span("root", None, "root-op"),
+            make_span("child", Some("root"), "child-op"),
+            make_span("grand", Some("child"), "grand-op"),
+        ];
+        let map = build_depth_map(&spans);
+        assert_eq!(map["grand"], 2);
+    }
+
+    #[test]
+    fn trace_entry_deserializes() {
+        let json = r#"{
+            "traceId": "abc123",
+            "serviceName": "api",
+            "route": "/health",
+            "durationMs": 42,
+            "status": "ok",
+            "startTime": "2024-01-15T10:00:00Z"
+        }"#;
+        let entry: TraceEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.trace_id, "abc123");
+        assert_eq!(entry.duration_ms, 42);
+    }
+
+    #[test]
+    fn span_deserializes_with_optional_parent() {
+        let json = r#"{
+            "spanId": "s1",
+            "name": "http.request",
+            "serviceName": "api",
+            "startTime": "2024-01-15T10:00:00Z",
+            "durationMs": 55
+        }"#;
+        let span: Span = serde_json::from_str(json).unwrap();
+        assert_eq!(span.span_id, "s1");
+        assert!(span.parent_span_id.is_none());
+    }
+
+    #[test]
+    fn trace_list_response_deserializes() {
+        let json = r#"{
+            "traces": [
+                {"traceId":"t1","serviceName":"api","route":"/","durationMs":10,"status":"ok","startTime":"2024-01-15T10:00:00Z"}
+            ],
+            "available": true
+        }"#;
+        let resp: TraceListResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.traces.len(), 1);
+        assert!(resp.available);
+    }
+
+    #[test]
+    fn trace_detail_response_deserializes() {
+        let json = r#"{
+            "traceId": "trace-001",
+            "spans": [
+                {"spanId":"s1","name":"root","serviceName":"api","startTime":"2024-01-15T10:00:00Z","durationMs":200}
+            ],
+            "available": true
+        }"#;
+        let resp: TraceDetailResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.trace_id, "trace-001");
+        assert_eq!(resp.spans.len(), 1);
+    }
+}

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -46,7 +46,7 @@ impl CliCommand for TracesCommand {
             .arg(
                 Arg::new("app_id")
                     .long("app-id")
-                    .help("Application ID (defaults to value from forklaunch.json)"),
+                    .help("Application ID (defaults to value from .forklaunch/manifest.toml)"),
             )
             .arg(
                 Arg::new("trace_id")
@@ -57,6 +57,7 @@ impl CliCommand for TracesCommand {
                 Arg::new("limit")
                     .long("limit")
                     .default_value("50")
+                    .value_parser(clap::value_parser!(u32).range(1..))
                     .help("Maximum number of traces to fetch (list mode only)"),
             )
             .arg(
@@ -97,9 +98,10 @@ impl CliCommand for TracesCommand {
             }
         } else {
             let limit = matches
-                .get_one::<String>("limit")
-                .cloned()
-                .unwrap_or_else(|| "50".to_string());
+                .get_one::<u32>("limit")
+                .copied()
+                .unwrap_or(50)
+                .to_string();
             let time_range = matches
                 .get_one::<String>("time_range")
                 .cloned()

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -30,93 +30,150 @@ impl TracesCommand {
 impl CliCommand for TracesCommand {
     fn command(&self) -> Command {
         command("traces", "Query distributed traces for a ForkLaunch application")
-            .arg(
-                Arg::new("base_path")
-                    .short('p')
-                    .long("path")
-                    .help("The application path"),
+            .subcommand_required(true)
+            .subcommand(
+                command("recent", "List recent traces for an application")
+                    .arg(
+                        Arg::new("base_path")
+                            .short('p')
+                            .long("path")
+                            .help("The application path"),
+                    )
+                    .arg(
+                        Arg::new("environment")
+                            .short('e')
+                            .long("environment")
+                            .required(true)
+                            .help("Environment to inspect (for example: dev, staging, production)"),
+                    )
+                    .arg(
+                        Arg::new("app_id")
+                            .long("app-id")
+                            .help("Application ID (defaults to value from forklaunch.json)"),
+                    )
+                    .arg(
+                        Arg::new("limit")
+                            .long("limit")
+                            .default_value("50")
+                            .help("Maximum number of traces to fetch"),
+                    )
+                    .arg(
+                        Arg::new("time_range")
+                            .long("time-range")
+                            .default_value("1h")
+                            .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
+                            .help("Time range for traces (15m, 1h, 6h, 24h, 7d, 30d)"),
+                    )
+                    .arg(
+                        Arg::new("json")
+                            .long("json")
+                            .help("Output raw JSON instead of formatted terminal output")
+                            .action(ArgAction::SetTrue),
+                    ),
             )
-            .arg(
-                Arg::new("environment")
-                    .short('e')
-                    .long("environment")
-                    .required(true)
-                    .help("Environment to inspect (for example: dev, staging, production)"),
-            )
-            .arg(
-                Arg::new("app_id")
-                    .long("app-id")
-                    .help("Application ID (defaults to value from forklaunch.json)"),
-            )
-            .arg(
-                Arg::new("id")
-                    .long("id")
-                    .help("Trace ID — triggers detail mode for a single trace"),
-            )
-            .arg(
-                Arg::new("limit")
-                    .long("limit")
-                    .default_value("50")
-                    .help("Maximum number of traces to fetch"),
-            )
-            .arg(
-                Arg::new("time_range")
-                    .long("time-range")
-                    .default_value("1h")
-                    .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
-                    .help("Time range for traces (15m, 1h, 6h, 24h, 7d, 30d)"),
-            )
-            .arg(
-                Arg::new("json")
-                    .long("json")
-                    .help("Output raw JSON instead of formatted terminal output")
-                    .action(ArgAction::SetTrue),
+            .subcommand(
+                command("show", "Drill into a single trace and display its span tree")
+                    .arg(
+                        Arg::new("base_path")
+                            .short('p')
+                            .long("path")
+                            .help("The application path"),
+                    )
+                    .arg(
+                        Arg::new("environment")
+                            .short('e')
+                            .long("environment")
+                            .required(true)
+                            .help("Environment to inspect (for example: dev, staging, production)"),
+                    )
+                    .arg(
+                        Arg::new("app_id")
+                            .long("app-id")
+                            .help("Application ID (defaults to value from forklaunch.json)"),
+                    )
+                    .arg(
+                        Arg::new("trace_id")
+                            .required(true)
+                            .help("Trace ID to inspect"),
+                    )
+                    .arg(
+                        Arg::new("json")
+                            .long("json")
+                            .help("Output raw JSON instead of formatted terminal output")
+                            .action(ArgAction::SetTrue),
+                    ),
             )
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
-        let environment = matches
-            .get_one::<String>("environment")
-            .context("--environment is required")?
-            .to_string();
-        let time_range = matches
-            .get_one::<String>("time_range")
-            .cloned()
-            .unwrap_or_else(|| "1h".to_string());
-        let limit = matches
-            .get_one::<String>("limit")
-            .cloned()
-            .unwrap_or_else(|| "50".to_string());
-        let trace_id = matches.get_one::<String>("id").cloned();
-        let json_output = matches.get_flag("json");
-
-        // Resolve application_id: prefer --app-id flag, fall back to manifest
-        let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
-            id
-        } else {
-            let (_app_root, manifest) = require_manifest(matches)?;
-            require_integration(&manifest)?
-        };
-
-        if let Some(tid) = trace_id {
-            let response = fetch_trace_detail(&application_id, &environment, &tid)?;
-            if json_output {
-                println!("{}", serde_json::to_string_pretty(&response)?);
-            } else {
-                print_trace_detail(&response)?;
-            }
-        } else {
-            let response =
-                fetch_traces(&application_id, &environment, &limit, &time_range)?;
-            if json_output {
-                println!("{}", serde_json::to_string_pretty(&response)?);
-            } else {
-                print_traces(&response.traces)?;
-            }
+        match matches.subcommand() {
+            Some(("recent", sub)) => handle_recent(sub),
+            Some(("show", sub)) => handle_show(sub),
+            _ => unreachable!("subcommand_required enforces a match"),
         }
-
-        Ok(())
     }
+}
+
+// ── Subcommand handlers ───────────────────────────────────────────────────────
+
+fn handle_recent(matches: &ArgMatches) -> Result<()> {
+    let environment = matches
+        .get_one::<String>("environment")
+        .context("--environment is required")?
+        .to_string();
+    let time_range = matches
+        .get_one::<String>("time_range")
+        .cloned()
+        .unwrap_or_else(|| "1h".to_string());
+    let limit = matches
+        .get_one::<String>("limit")
+        .cloned()
+        .unwrap_or_else(|| "50".to_string());
+    let json_output = matches.get_flag("json");
+
+    let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
+        id
+    } else {
+        let (_app_root, manifest) = require_manifest(matches)?;
+        require_integration(&manifest)?
+    };
+
+    let response = fetch_traces(&application_id, &environment, &limit, &time_range)?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        print_traces(&response.traces)?;
+    }
+
+    Ok(())
+}
+
+fn handle_show(matches: &ArgMatches) -> Result<()> {
+    let environment = matches
+        .get_one::<String>("environment")
+        .context("--environment is required")?
+        .to_string();
+    let trace_id = matches
+        .get_one::<String>("trace_id")
+        .context("trace ID is required")?
+        .to_string();
+    let json_output = matches.get_flag("json");
+
+    let application_id = if let Some(id) = matches.get_one::<String>("app_id").cloned() {
+        id
+    } else {
+        let (_app_root, manifest) = require_manifest(matches)?;
+        require_integration(&manifest)?
+    };
+
+    let response = fetch_trace_detail(&application_id, &environment, &trace_id)?;
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        print_trace_detail(&response)?;
+    }
+
+    Ok(())
 }
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
@@ -271,12 +328,11 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         return Ok(());
     }
 
-    // Build parent -> children map for indentation
     let depth_map = build_depth_map(&response.spans);
 
     for span in &response.spans {
         let depth = depth_map.get(&span.span_id).copied().unwrap_or(0);
-        let indent = "  ".repeat(depth + 1); // base 1-level indent for all spans
+        let indent = "  ".repeat(depth + 1);
 
         let is_error = span
             .attributes
@@ -297,11 +353,7 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         stdout.reset()?;
 
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
-        writeln!(
-            stdout,
-            "  ({}, {}ms)",
-            span.service_name, span.duration_ms
-        )?;
+        writeln!(stdout, "  ({}, {}ms)", span.service_name, span.duration_ms)?;
         stdout.reset()?;
     }
 
@@ -316,7 +368,6 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
 
 /// Returns a map from spanId -> depth (root = 0).
 fn build_depth_map(spans: &[Span]) -> HashMap<String, usize> {
-    // Build parent -> children adjacency
     let mut children: HashMap<Option<String>, Vec<&Span>> = HashMap::new();
     for span in spans {
         children

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -278,7 +278,14 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         let depth = depth_map.get(&span.span_id).copied().unwrap_or(0);
         let indent = "  ".repeat(depth + 1); // base 1-level indent for all spans
 
-        let color = if span.duration_ms > 1000 {
+        let is_error = span
+            .attributes
+            .get("otel.status_code")
+            .map(|v| v.as_str() == "ERROR")
+            .unwrap_or(false);
+        let color = if is_error {
+            Color::Red
+        } else if span.duration_ms > 1000 {
             Color::Yellow
         } else {
             Color::Green

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, io::Write};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Write,
+};
 
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
@@ -29,50 +32,53 @@ impl TracesCommand {
 
 impl CliCommand for TracesCommand {
     fn command(&self) -> Command {
-        command("traces", "Query distributed traces for a ForkLaunch application")
-            .arg(
-                Arg::new("base_path")
-                    .short('p')
-                    .long("path")
-                    .help("The application path"),
-            )
-            .arg(
-                Arg::new("environment")
-                    .short('e')
-                    .long("environment")
-                    .required(true)
-                    .help("Environment to inspect (for example: dev, staging, production)"),
-            )
-            .arg(
-                Arg::new("app_id")
-                    .long("app-id")
-                    .help("Application ID (defaults to value from .forklaunch/manifest.toml)"),
-            )
-            .arg(
-                Arg::new("trace_id")
-                    .long("trace-id")
-                    .help("Trace ID — show full span tree for a single trace"),
-            )
-            .arg(
-                Arg::new("limit")
-                    .long("limit")
-                    .default_value("50")
-                    .value_parser(clap::value_parser!(u32).range(1..))
-                    .help("Maximum number of traces to fetch (list mode only)"),
-            )
-            .arg(
-                Arg::new("time_range")
-                    .long("time-range")
-                    .default_value("1h")
-                    .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
-                    .help("Time range for traces (list mode only): 15m, 1h, 6h, 24h, 7d, 30d"),
-            )
-            .arg(
-                Arg::new("json")
-                    .long("json")
-                    .help("Output raw JSON instead of formatted terminal output")
-                    .action(ArgAction::SetTrue),
-            )
+        command(
+            "traces",
+            "Query distributed traces for a ForkLaunch application",
+        )
+        .arg(
+            Arg::new("base_path")
+                .short('p')
+                .long("path")
+                .help("The application path"),
+        )
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to inspect (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("app_id")
+                .long("app-id")
+                .help("Application ID (defaults to value from .forklaunch/manifest.toml)"),
+        )
+        .arg(
+            Arg::new("trace_id")
+                .long("trace-id")
+                .help("Trace ID — show full span tree for a single trace"),
+        )
+        .arg(
+            Arg::new("limit")
+                .long("limit")
+                .default_value("50")
+                .value_parser(clap::value_parser!(u32).range(1..))
+                .help("Maximum number of traces to fetch (list mode only)"),
+        )
+        .arg(
+            Arg::new("time_range")
+                .long("time-range")
+                .default_value("1h")
+                .value_parser(["15m", "1h", "6h", "24h", "7d", "30d"])
+                .help("Time range for traces (list mode only): 15m, 1h, 6h, 24h, 7d, 30d"),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
@@ -218,7 +224,10 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
     for trace in traces {
         let trace_id_short = trace.trace_id.get(..12).unwrap_or(&trace.trace_id);
         let service = if trace.service_name.chars().count() > 20 {
-            format!("{}…", trace.service_name.chars().take(19).collect::<String>())
+            format!(
+                "{}…",
+                trace.service_name.chars().take(19).collect::<String>()
+            )
         } else {
             trace.service_name.clone()
         };
@@ -236,7 +245,11 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
 
         let color = status_color(&trace.status);
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
-        write!(stdout, "  {:<14}  {:<20}  {:<30}  {:<10}  ", trace_id_short, service, route, duration)?;
+        write!(
+            stdout,
+            "  {:<14}  {:<20}  {:<30}  {:<10}  ",
+            trace_id_short, service, route, duration
+        )?;
         stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
         write!(stdout, "{:<10}", trace.status)?;
         stdout.reset()?;
@@ -269,10 +282,9 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         return Ok(());
     }
 
-    let depth_map = build_depth_map(&response.spans);
-
-    for span in &response.spans {
-        let depth = depth_map.get(&span.span_id).copied().unwrap_or(0);
+    // Render in tree order (parent before its children), not the raw order the
+    // API returned them in — otherwise a child can print above its parent.
+    for (span, depth) in build_ordered_spans(&response.spans) {
         let indent = "  ".repeat(depth + 1);
 
         let is_error = span
@@ -307,8 +319,11 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
     Ok(())
 }
 
-/// Returns a map from spanId -> depth (root = 0).
-fn build_depth_map(spans: &[Span]) -> HashMap<String, usize> {
+/// Returns spans in DFS pre-order (parent immediately before its children),
+/// each paired with its depth (root = 0). Siblings keep their original order.
+/// Orphaned spans — whose parent isn't in the set — are appended at the end at
+/// depth 0 so a partial trace still renders every span instead of dropping some.
+fn build_ordered_spans(spans: &[Span]) -> Vec<(&Span, usize)> {
     let mut children: HashMap<Option<String>, Vec<&Span>> = HashMap::new();
     for span in spans {
         children
@@ -317,23 +332,37 @@ fn build_depth_map(spans: &[Span]) -> HashMap<String, usize> {
             .push(span);
     }
 
-    let mut depth_map: HashMap<String, usize> = HashMap::new();
-    // DFS from roots (parent_span_id == None)
-    let mut queue: Vec<(&Span, usize)> = children
-        .get(&None)
-        .map(|roots| roots.iter().map(|s| (*s, 0usize)).collect())
-        .unwrap_or_default();
+    let mut ordered: Vec<(&Span, usize)> = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
 
-    while let Some((span, depth)) = queue.pop() {
-        depth_map.insert(span.span_id.clone(), depth);
+    // Stack-based DFS. Push siblings in reverse so they pop in original order
+    // and each subtree is emitted fully before the next sibling.
+    let mut stack: Vec<(&Span, usize)> = Vec::new();
+    if let Some(roots) = children.get(&None) {
+        for root in roots.iter().rev() {
+            stack.push((root, 0));
+        }
+    }
+    while let Some((span, depth)) = stack.pop() {
+        if !visited.insert(span.span_id.clone()) {
+            continue;
+        }
+        ordered.push((span, depth));
         if let Some(kids) = children.get(&Some(span.span_id.clone())) {
-            for kid in kids {
-                queue.push((kid, depth + 1));
+            for kid in kids.iter().rev() {
+                stack.push((kid, depth + 1));
             }
         }
     }
 
-    depth_map
+    // Append orphans (parent not present in the trace) so nothing is dropped.
+    for span in spans {
+        if !visited.contains(&span.span_id) {
+            ordered.push((span, 0));
+        }
+    }
+
+    ordered
 }
 
 fn status_color(status: &str) -> Color {
@@ -396,6 +425,14 @@ struct TraceDetailResponse {
 mod tests {
     use super::*;
 
+    /// spanId -> depth, derived from the tree walk. Test-only convenience.
+    fn build_depth_map(spans: &[Span]) -> HashMap<String, usize> {
+        build_ordered_spans(spans)
+            .into_iter()
+            .map(|(span, depth)| (span.span_id.clone(), depth))
+            .collect()
+    }
+
     fn make_span(span_id: &str, parent_span_id: Option<&str>, name: &str) -> Span {
         Span {
             span_id: span_id.to_string(),
@@ -452,6 +489,54 @@ mod tests {
         ];
         let map = build_depth_map(&spans);
         assert_eq!(map["grand"], 2);
+    }
+
+    #[test]
+    fn ordered_spans_are_tree_order_not_input_order() {
+        // API returns children before parents (chronological-ish). The tree
+        // walk must still emit each parent before its own children.
+        let spans = vec![
+            make_span("grand", Some("child"), "grand-op"),
+            make_span("child", Some("root"), "child-op"),
+            make_span("root", None, "root-op"),
+        ];
+        let order: Vec<&str> = build_ordered_spans(&spans)
+            .iter()
+            .map(|(s, _)| s.span_id.as_str())
+            .collect();
+        assert_eq!(order, vec!["root", "child", "grand"]);
+    }
+
+    #[test]
+    fn ordered_spans_group_subtrees_before_siblings() {
+        // root has two children; each child's subtree must be emitted fully
+        // before moving to the next sibling.
+        let spans = vec![
+            make_span("root", None, "root-op"),
+            make_span("a", Some("root"), "a-op"),
+            make_span("b", Some("root"), "b-op"),
+            make_span("a1", Some("a"), "a1-op"),
+        ];
+        let order: Vec<&str> = build_ordered_spans(&spans)
+            .iter()
+            .map(|(s, _)| s.span_id.as_str())
+            .collect();
+        assert_eq!(order, vec!["root", "a", "a1", "b"]);
+    }
+
+    #[test]
+    fn ordered_spans_keep_orphans() {
+        // A span whose parent isn't present must still render, not vanish.
+        let spans = vec![
+            make_span("root", None, "root-op"),
+            make_span("orphan", Some("missing"), "orphan-op"),
+        ];
+        let ids: Vec<&str> = build_ordered_spans(&spans)
+            .iter()
+            .map(|(s, _)| s.span_id.as_str())
+            .collect();
+        assert!(ids.contains(&"root"));
+        assert!(ids.contains(&"orphan"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `observe metrics` subcommand to the Forklaunch CLI for querying application metrics (request rate, error rate, latency p50/p95/p99, uptime) or raw PromQL queries
- Adds `observe traces` subcommand for listing distributed traces and drilling into a single trace's span tree
- Wires both subcommands into `observe/mod.rs`

## Changes

### `cli/src/observe/metrics.rs` (new)
`MetricsCommand` implementing `CliCommand`. Args: `-e/--environment` (required), `--app-id`, `--time-range` (default `1h`, validated against 15m|1h|6h|24h|7d|30d), `--query` (raw PromQL), `--json`. With `--query`: `POST /monitoring/promql`; without: `GET /applications/:appId/monitoring?environment=...&timeRange=...`. Default display: colored table of metric rows (name, value, unit). Types: `ApplicationMonitoringResponse`, `MetricValue`, `LatencyMetric`, `PromQLResponse`.

### `cli/src/observe/traces.rs` (new)
`TracesCommand` implementing `CliCommand`. Args: `-e/--environment` (required), `--app-id`, `--id` (detail mode), `--limit` (default `50`), `--time-range` (default `1h`), `--json`. With `--id`: `GET /applications/:appId/traces/:traceId?environment=...`; without: `GET /applications/:appId/traces?environment=...&limit=...&timeRange=...`. List display: colored table (traceId first 12 chars, service, route, durationMs, status, startTime). Detail display: span tree with depth-based indentation (2 spaces per level) built by BFS from roots. Types: `TraceEntry`, `TraceListResponse`, `Span`, `TraceDetailResponse`.

### `cli/src/observe/mod.rs` (modified)
Added `mod metrics; mod traces;`, added `metrics: MetricsCommand` and `traces: TracesCommand` fields to `ObserveCommand`, registered both in `.subcommand()` chain and `handler()` match arms.

## Test plan

- [x] `cargo build` — clean compile, 0 errors
- [x] `cargo test` — 293 tests passed, 0 failed (includes 6 new metrics tests and 10 new traces tests)
- [ ] Manual smoke test against staging: `forklaunch observe metrics -e dev --app-id <id>`
- [ ] Manual smoke test detail view: `forklaunch observe traces -e dev --app-id <id> --id <traceId>`
- [ ] Verify `--json` flag emits raw JSON for both subcommands

Closes FOR-96 / OBS-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **metrics** subcommand to fetch application metrics or run raw PromQL queries, supporting environment selection, time ranges, optional app ID resolution, and **JSON** output.
  * Added a **traces** subcommand to list distributed traces or view a specific trace by trace ID, with configurable limits/time ranges and color-coded span display.
  * Extended the main **observe** command to include **metrics** and **traces** alongside the existing **status** and **logs** subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->