### PR TITLE
cli: honor FORKLAUNCH_SKIP_FORMAT to skip per-command format pass

### DIFF
--- a/cli/src/core/format.rs
+++ b/cli/src/core/format.rs
@@ -3,6 +3,13 @@ use std::path::Path;
 use crate::{constants::Runtime, core::openapi_export::resolve_command};
 
 pub(crate) fn format_code(base_path: &Path, runtime: &Runtime) {
+    // Opt-out for callers that run their own format/lint pass afterward (e.g. the ForkLaunch
+    // Studio orchestrator). The `format` script globs `**/*` and walks the pnpm-symlinked
+    // node_modules tree, which can peg a core for minutes on a populated module — pure waste
+    // when the caller reformats everything anyway. Default behavior is unchanged.
+    if std::env::var_os("FORKLAUNCH_SKIP_FORMAT").is_some() {
+        return;
+    }
     let command = match runtime {
         Runtime::Node => "pnpm",
         Runtime::Bun => "bun",


### PR DESCRIPTION
Lets callers that run their own format/lint (the ForkLaunch Studio orchestrator) skip the CLI's per-command `format` script, which globs `**/*` and walks node_modules — minutes on a populated module. Default behavior unchanged (env unset = format runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to skip code formatting by setting an environment variable, providing greater control over build workflow customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->