### PR TITLE
fix(express): skip body parsers in OpenAPI export mode (resilient spec generation)

### DIFF
--- a/framework/express/src/expressApplication.ts
+++ b/framework/express/src/expressApplication.ts
@@ -86,10 +86,19 @@ export class Application<
     super(
       schemaValidator,
       express(),
-      [
-        contentParse<SV>(options),
-        enrichResponseTransmission as unknown as RequestHandler
-      ],
+      // In OpenAPI export mode the app never serves requests — `listen` just
+      // generates the spec and exits — so request body parsers are unnecessary.
+      // Constructing them eagerly can hard-crash the export when runtime config
+      // is unset/empty (e.g. body-parser@2 rejects an empty `limit` string that
+      // can materialize from empty-string env under `FORKLAUNCH_MODE=openapi`).
+      // Skip them in openapi mode so spec generation is resilient to missing
+      // runtime configuration.
+      process.env.FORKLAUNCH_MODE === 'openapi'
+        ? [enrichResponseTransmission as unknown as RequestHandler]
+        : [
+            contentParse<SV>(options),
+            enrichResponseTransmission as unknown as RequestHandler
+          ],
       openTelemetryCollector,
       options
     );


### PR DESCRIPTION
## Problem

`forklaunch release create` aborts at a service's OpenAPI export:

```
Service <name> failed to export: option limit "" is invalid
  body-parser normalizeOptions ← express.json() ← contentParse
  ← Application constructor ← forklaunchExpress ← <service>/server.ts
```

**Root cause:** in `FORKLAUNCH_MODE=openapi` the app is booted *only* to generate the spec — `listen()` writes the spec and `process.exit`s without ever serving a request. But the `Application` constructor **eagerly builds the express body parsers**, and that construction hard-crashes when runtime config is unset/empty: **body-parser@2** (Express 5) rejects an empty-string `limit` (body-parser@1 silently ignored it), and empty strings leak in from environments that materialize unset config as `""`. In export mode the async `ExpressApplicationOptions` factory isn't applied, so an empty `limit` reaches `express.json()`. (The same export pass also surfaces `ENCRYPTION_KEY=""` reaching `FieldEncryptor` — same "empty string != unset" smell.)

First hit on a Better Auth IAM service (the only one on the full `ExpressApplicationOptions` path).

## Fix

Make openapi-mode construction **resilient** rather than papering over the limit value: **skip building the request body parsers when `FORKLAUNCH_MODE === 'openapi'`**. They are never used (no requests are served) and aren't needed for spec generation, so missing/empty runtime config can no longer crash the export. Normal serving mode is unchanged.

> (Chosen over coercing an empty `limit` to a default inside `contentParse` — fixing the openapi path is the cleaner root cause.)

## Scope
- One file: `framework/express/src/expressApplication.ts`.
- hyper-express unaffected (uWebSockets parsers, no body-parser).

## Optional follow-up (not in this PR)
The deeper cause is the export materializing unset config as empty strings. The export harness could pass `undefined`/omit unset env under `FORKLAUNCH_MODE=openapi` so framework defaults apply everywhere (also covers the `ENCRYPTION_KEY=""` case).

Generated with Claude Code