### PR TITLE
feat(cli): add fl infra command group (list, status, resize, config-set, stop, delete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ lib
 target
 
 agentic-capital
+
+.gstack

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ oxc_ast_visit = "0.80.0"
 oxc_span = "0.80.0"
 paste = "1.0.15"
 pathdiff = "0.2.3"
+percent-encoding = "2.3.1"
 ramhorns = "1.0.1"
 rcgen = "0.14.3"
 reqwest = { version = "0.13.2", features = ["blocking", "json", "native-tls-vendored"] }

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -12,12 +12,14 @@ const DEV_OBSERVABILITY_API_URL: &str = "http://localhost:8007";
 const DEV_IAM_API_URL: &str = "http://localhost:8001";
 const DEV_BILLING_API_URL: &str = "http://localhost:8000";
 const DEV_PLATFORM_UI_URL: &str = "http://localhost:5173";
+const DEV_RESOURCE_MANAGEMENT_API_URL: &str = "http://localhost:8005";
 
 const PROD_PLATFORM_MANAGEMENT_API_URL: &str = "https://platform-management.forklaunch.com";
 const PROD_OBSERVABILITY_API_URL: &str = "https://observability-api.forklaunch.com";
 const PROD_IAM_API_URL: &str = "https://iam.forklaunch.com";
 const PROD_BILLING_API_URL: &str = "https://billing.forklaunch.com";
 const PROD_PLATFORM_UI_URL: &str = "https://forklaunch.com";
+const PROD_RESOURCE_MANAGEMENT_API_URL: &str = "https://resource-management.forklaunch.com";
 
 pub(crate) fn is_dev_build() -> bool {
     std::env::current_exe()
@@ -90,6 +92,17 @@ pub(crate) fn get_platform_ui_url() -> String {
             DEV_PLATFORM_UI_URL
         } else {
             PROD_PLATFORM_UI_URL
+        }
+        .to_string()
+    })
+}
+
+pub(crate) fn get_resource_management_api_url() -> String {
+    std::env::var("FORKLAUNCH_RESOURCE_MANAGEMENT_API_URL").unwrap_or_else(|_| {
+        if is_dev_build() {
+            DEV_RESOURCE_MANAGEMENT_API_URL
+        } else {
+            PROD_RESOURCE_MANAGEMENT_API_URL
         }
         .to_string()
     })

--- a/cli/src/core/http_client.rs
+++ b/cli/src/core/http_client.rs
@@ -57,13 +57,21 @@ fn try_authenticated_request(
     let mut request = client
         .request(method, url)
         .header("Authorization", format!("Bearer {}", token))
-        .header("Accept", "application/json");
+        .header("Accept", "application/json")
+        .header("User-Agent", user_agent());
 
     if let Some(json_body) = body {
         request = request.json(&json_body);
     }
 
     Ok(request.send()?)
+}
+
+/// Identifies this CLI as the caller in platform request logs — lets the platform
+/// distinguish CLI-originated mutations (e.g. `fl infra resize`) from dashboard-UI
+/// or other callers of the same endpoints.
+fn user_agent() -> String {
+    format!("forklaunch-cli/{}", env!("CARGO_PKG_VERSION"))
 }
 
 /// Handles authentication failure by refreshing token or triggering re-login
@@ -107,6 +115,11 @@ pub fn post(url: &str, body: Value) -> Result<Response> {
 /// Helper to make a PUT request with authentication
 pub fn put(url: &str, body: Value) -> Result<Response> {
     make_authenticated_request(Method::PUT, url, Some(body))
+}
+
+/// Helper to make a PATCH request with authentication
+pub fn patch(url: &str, body: Value) -> Result<Response> {
+    make_authenticated_request(Method::PATCH, url, Some(body))
 }
 
 /// Extract the path component from a full URL (e.g. "https://host:port/path?q" -> "/path?q")
@@ -159,7 +172,8 @@ fn make_hmac_request_with_sign_path(
     let mut request = client
         .request(method, url)
         .header("Authorization", auth_header)
-        .header("Accept", "application/json");
+        .header("Accept", "application/json")
+        .header("User-Agent", user_agent());
 
     if let Some(json_body) = body {
         request = request.json(&json_body);
@@ -212,6 +226,16 @@ pub fn put_with_auth(auth_mode: &AuthMode, url: &str, body: Value) -> Result<Res
         AuthMode::Jwt => put(url, body),
         AuthMode::Hmac { secret_key } => {
             make_hmac_request(secret_key, Method::PUT, url, Some(body))
+        }
+    }
+}
+
+/// PATCH with auth mode dispatch (JWT or HMAC)
+pub fn patch_with_auth(auth_mode: &AuthMode, url: &str, body: Value) -> Result<Response> {
+    match auth_mode {
+        AuthMode::Jwt => patch(url, body),
+        AuthMode::Hmac { secret_key } => {
+            make_hmac_request(secret_key, Method::PATCH, url, Some(body))
         }
     }
 }

--- a/cli/src/deploy/utils.rs
+++ b/cli/src/deploy/utils.rs
@@ -109,8 +109,11 @@ pub(crate) fn stream_deployment_status(
     Ok(())
 }
 
-fn display_phase_update(phase: &str, stdout: &mut StandardStream) -> Result<()> {
-    let message = match phase {
+/// Maps a deployment phase string to a human-readable message. Unrecognized phases
+/// (e.g. new resource-modify phases like "modifying_database") fall back to the raw
+/// phase string rather than panicking or dropping the update silently.
+fn phase_message(phase: &str) -> &str {
+    match phase {
         "validating" => "  Validating configuration...",
         "provisioning_database" => "  Provisioning database (RDS PostgreSQL db.t3.micro)...",
         "provisioning_cache" => "  Provisioning cache (ElastiCache Redis)...",
@@ -125,7 +128,28 @@ fn display_phase_update(phase: &str, stdout: &mut StandardStream) -> Result<()> 
         "destroying_cache" => "  Destroying cache...",
         "destroying_database" => "  Destroying database...",
         _ => phase,
-    };
-    log_info!(stdout, "{}", message);
+    }
+}
+
+fn display_phase_update(phase: &str, stdout: &mut StandardStream) -> Result<()> {
+    log_info!(stdout, "{}", phase_message(phase));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_phase_maps_to_human_message() {
+        assert_eq!(phase_message("validating"), "  Validating configuration...");
+    }
+
+    #[test]
+    fn unrecognized_phase_falls_back_to_raw_string() {
+        // Locks in the defensive fallback: a resource-modify deployment emitting a
+        // phase name not in this match (e.g. "modifying_database") must not panic
+        // or print nothing — it should surface the raw phase string.
+        assert_eq!(phase_message("modifying_database"), "modifying_database");
+    }
 }

--- a/cli/src/infra/config_set.rs
+++ b/cli/src/infra/config_set.rs
@@ -1,0 +1,173 @@
+use anyhow::{Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_integration, require_manifest, resolve_auth},
+    },
+};
+
+use super::{
+    mutation::{MutationRequest, nothing_to_change, run_mutation},
+    resource_resolver::{fetch_resource_detail, require_jwt_mode, resolve},
+    types::ResourceConfig,
+};
+
+#[derive(Debug)]
+pub(super) struct ConfigSetCommand;
+
+impl ConfigSetCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ConfigSetCommand {
+    fn command(&self) -> Command {
+        command(
+            "config-set",
+            "Change the configuration of a provisioned database, cache, or queue resource",
+        )
+        .arg(
+            Arg::new("resource")
+                .help("Resource identifier: <project-name>:<resource-type> (e.g. billing-service:database)")
+                .required(true),
+        )
+        .arg(Arg::new("base_path").short('p').long("path").help("The application path"))
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to target (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("resource_id")
+                .long("resource-id")
+                .help("Skip name resolution and address a resource by its platform id directly"),
+        )
+        .arg(Arg::new("engine").long("engine").help("Database/cache engine"))
+        .arg(
+            Arg::new("multi_az")
+                .long("multi-az")
+                .help("Enable Multi-AZ (database)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(Arg::new("queue_type").long("queue-type").help("Queue type"))
+        .arg(
+            Arg::new("visibility_timeout")
+                .long("visibility-timeout")
+                .value_parser(clap::value_parser!(u32))
+                .help("Queue visibility timeout (seconds)"),
+        )
+        .arg(
+            Arg::new("message_retention_seconds")
+                .long("message-retention-seconds")
+                .value_parser(clap::value_parser!(u32))
+                .help("Queue message retention (seconds)"),
+        )
+        .arg(Arg::new("encryption").long("encryption").help("Encryption setting"))
+        .arg(Arg::new("kafka_version").long("kafka-version").help("Kafka version (queue)"))
+        .arg(
+            Arg::new("port")
+                .long("port")
+                .value_parser(clap::value_parser!(u16))
+                .help("Port"),
+        )
+        .arg(
+            Arg::new("distribution_strategy")
+                .long("distribution-strategy")
+                .help("Resource distribution strategy (centralized or distributed)"),
+        )
+        .arg(
+            Arg::new("primary_region")
+                .long("primary-region")
+                .help("Primary region for the resource"),
+        )
+        .arg(
+            Arg::new("snapshot_before_change")
+                .long("snapshot-before-change")
+                .help("Take a snapshot before applying the change (database)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .help("Skip the confirmation prompt (for CI/scripted use)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("dry_run")
+                .long("dry-run")
+                .help("Print the change without applying it")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_auth()?;
+        require_jwt_mode(&auth_mode)?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("--environment is required")
+            .to_string();
+        let resource_arg = matches
+            .get_one::<String>("resource")
+            .expect("<resource> is required");
+        let resource_id_override = matches.get_one::<String>("resource_id").map(String::as_str);
+
+        let requested_config = ResourceConfig {
+            engine: matches.get_one::<String>("engine").cloned(),
+            multi_az: if matches.get_flag("multi_az") { Some(true) } else { None },
+            queue_type: matches.get_one::<String>("queue_type").cloned(),
+            visibility_timeout: matches.get_one::<u32>("visibility_timeout").copied(),
+            message_retention_seconds: matches.get_one::<u32>("message_retention_seconds").copied(),
+            encryption: matches.get_one::<String>("encryption").cloned(),
+            kafka_version: matches.get_one::<String>("kafka_version").cloned(),
+            port: matches.get_one::<u16>("port").copied(),
+            ..Default::default()
+        };
+        let distribution_strategy = matches.get_one::<String>("distribution_strategy").cloned();
+        let primary_region = matches.get_one::<String>("primary_region").cloned();
+
+        // Fail before any network call — resolving the resource and fetching its
+        // current detail are both wasted if there's nothing to change.
+        if nothing_to_change(&requested_config, &distribution_strategy, &primary_region) {
+            bail!("nothing to change — pass at least one config or distribution flag");
+        }
+
+        let resolved = resolve(
+            &auth_mode,
+            &manifest,
+            &application_id,
+            &environment,
+            resource_arg,
+            resource_id_override,
+        )?;
+
+        let current = fetch_resource_detail(&auth_mode, &resolved.id)?;
+
+        run_mutation(
+            &auth_mode,
+            MutationRequest {
+                resource_id: resolved.id,
+                current,
+                requested_config,
+                distribution_strategy,
+                primary_region,
+                snapshot_before_change: if matches.get_flag("snapshot_before_change") {
+                    Some(true)
+                } else {
+                    None
+                },
+                skip_confirm: matches.get_flag("yes"),
+                dry_run: matches.get_flag("dry_run"),
+            },
+        )
+    }
+}

--- a/cli/src/infra/delete.rs
+++ b/cli/src/infra/delete.rs
@@ -1,0 +1,110 @@
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use dialoguer::{Input, theme::ColorfulTheme};
+
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_integration, require_manifest, resolve_auth},
+    },
+};
+
+use super::{
+    lifecycle::call_lifecycle_action,
+    resource_resolver::{fetch_resource_detail, require_jwt_mode, resolve},
+};
+
+#[derive(Debug)]
+pub(super) struct DeleteCommand;
+
+impl DeleteCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for DeleteCommand {
+    fn command(&self) -> Command {
+        command(
+            "delete",
+            "Permanently delete a provisioned database, cache, or queue resource and its AWS infrastructure",
+        )
+        .arg(
+            Arg::new("resource")
+                .help("Resource identifier: <project-name>:<resource-type> (e.g. billing-service:database)")
+                .required(true),
+        )
+        .arg(Arg::new("base_path").short('p').long("path").help("The application path"))
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to target (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("resource_id")
+                .long("resource-id")
+                .help("Skip name resolution and address a resource by its platform id directly"),
+        )
+        .arg(
+            Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .help("Skip the confirmation prompt (for CI/scripted use) — use with care, this is irreversible")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_auth()?;
+        require_jwt_mode(&auth_mode)?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("--environment is required")
+            .to_string();
+        let resource_arg = matches
+            .get_one::<String>("resource")
+            .expect("<resource> is required");
+        let resource_id_override = matches.get_one::<String>("resource_id").map(String::as_str);
+        let skip_confirm = matches.get_flag("yes");
+
+        let resolved = resolve(
+            &auth_mode,
+            &manifest,
+            &application_id,
+            &environment,
+            resource_arg,
+            resource_id_override,
+        )?;
+
+        let detail = fetch_resource_detail(&auth_mode, &resolved.id)?;
+
+        if !skip_confirm {
+            println!(
+                "This will PERMANENTLY DELETE {} ({}) and its AWS infrastructure.",
+                detail.name, detail.r#type
+            );
+            println!("This action cannot be undone — no snapshot is taken automatically before deletion.");
+            println!();
+
+            let typed: String = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!("Type the resource name ({}) to confirm", detail.name))
+                .allow_empty(true)
+                .interact_text()
+                .with_context(|| "Failed to read confirmation")?;
+
+            if typed != detail.name {
+                bail!("confirmation did not match '{}' — aborted, nothing was deleted", detail.name);
+            }
+        }
+
+        let result = call_lifecycle_action(&auth_mode, &resolved.id, "delete")?;
+        println!("{}", result.message);
+
+        Ok(())
+    }
+}

--- a/cli/src/infra/lifecycle.rs
+++ b/cli/src/infra/lifecycle.rs
@@ -5,7 +5,7 @@ use crate::{
     core::{hmac::AuthMode, http_client::post_with_auth},
 };
 
-use super::types::MessageResponse;
+use super::{resource_resolver::encode_resource_id_for_url, types::MessageResponse};
 
 /// `POST /:id/stop` and `POST /:id/delete` both take no request body and return a
 /// synchronous `{message: string}` — no `deploymentId`, no polling. Shared by
@@ -18,7 +18,7 @@ pub(crate) fn call_lifecycle_action(
     let url = format!(
         "{}/platform-resources/{}/{}",
         get_resource_management_api_url(),
-        resource_id,
+        encode_resource_id_for_url(resource_id),
         action
     );
 

--- a/cli/src/infra/lifecycle.rs
+++ b/cli/src/infra/lifecycle.rs
@@ -1,0 +1,41 @@
+use anyhow::{Context, Result, bail};
+
+use crate::{
+    constants::get_resource_management_api_url,
+    core::{hmac::AuthMode, http_client::post_with_auth},
+};
+
+use super::types::MessageResponse;
+
+/// `POST /:id/stop` and `POST /:id/delete` both take no request body and return a
+/// synchronous `{message: string}` — no `deploymentId`, no polling. Shared by
+/// `stop.rs` and `delete.rs`; only the URL suffix and the confirmation UX differ.
+pub(crate) fn call_lifecycle_action(
+    auth_mode: &AuthMode,
+    resource_id: &str,
+    action: &str,
+) -> Result<MessageResponse> {
+    let url = format!(
+        "{}/platform-resources/{}/{}",
+        get_resource_management_api_url(),
+        resource_id,
+        action
+    );
+
+    // Neither route declares a request body schema — send an empty object rather
+    // than `null`, the more conventional "no meaningful body" shape for a POST.
+    let response = post_with_auth(auth_mode, &url, serde_json::json!({}))
+        .with_context(|| "Failed to reach resource-management API")?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        bail!("resource-management API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse response")
+}

--- a/cli/src/infra/list.rs
+++ b/cli/src/infra/list.rs
@@ -1,0 +1,102 @@
+use std::io::Write;
+
+use anyhow::Result;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{Color, ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_integration, require_manifest, resolve_auth},
+    },
+};
+
+use super::resource_resolver::{fetch_application_resources, require_jwt_mode};
+
+#[derive(Debug)]
+pub(super) struct ListCommand;
+
+impl ListCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ListCommand {
+    fn command(&self) -> Command {
+        command("list", "List provisioned infrastructure resources for an application")
+            .arg(
+                Arg::new("base_path")
+                    .short('p')
+                    .long("path")
+                    .help("The application path"),
+            )
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .required(true)
+                    .help("Environment to inspect (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_auth()?;
+        require_jwt_mode(&auth_mode)?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("--environment is required")
+            .to_string();
+        let json_output = matches.get_flag("json");
+
+        let resources = fetch_application_resources(&auth_mode, &application_id, &environment)?;
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&resources.iter().map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "type": r.r#type,
+                    "serviceName": r.service_name,
+                    "environment": r.environment,
+                    "region": r.region,
+                    "status": r.status,
+                })
+            }).collect::<Vec<_>>())?);
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        writeln!(stdout)?;
+        stdout.set_color(termcolor::ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+        writeln!(stdout, "Infrastructure resources for {}", environment)?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        if resources.is_empty() {
+            writeln!(stdout, "  No resources provisioned in this environment.")?;
+        } else {
+            for r in &resources {
+                writeln!(
+                    stdout,
+                    "  {:<24} {:<12} {:<10} {}",
+                    r.service_name.as_deref().unwrap_or("?"),
+                    r.r#type,
+                    r.status,
+                    r.region.as_deref().unwrap_or("")
+                )?;
+            }
+        }
+        writeln!(stdout)?;
+
+        Ok(())
+    }
+}

--- a/cli/src/infra/mod.rs
+++ b/cli/src/infra/mod.rs
@@ -4,17 +4,22 @@ use clap::{ArgMatches, Command};
 use crate::{CliCommand, core::command::command};
 
 mod config_set;
+mod delete;
+mod lifecycle;
 mod list;
 mod mutation;
 mod resize;
 mod resource_resolver;
 mod status;
+mod stop;
 mod types;
 
 use config_set::ConfigSetCommand;
+use delete::DeleteCommand;
 use list::ListCommand;
 use resize::ResizeCommand;
 use status::StatusCommand;
+use stop::StopCommand;
 
 #[derive(Debug)]
 pub(crate) struct InfraCommand {
@@ -22,6 +27,8 @@ pub(crate) struct InfraCommand {
     status: StatusCommand,
     resize: ResizeCommand,
     config_set: ConfigSetCommand,
+    stop: StopCommand,
+    delete: DeleteCommand,
 }
 
 impl InfraCommand {
@@ -31,6 +38,8 @@ impl InfraCommand {
             status: StatusCommand::new(),
             resize: ResizeCommand::new(),
             config_set: ConfigSetCommand::new(),
+            stop: StopCommand::new(),
+            delete: DeleteCommand::new(),
         }
     }
 }
@@ -45,6 +54,8 @@ impl CliCommand for InfraCommand {
         .subcommand(self.status.command())
         .subcommand(self.resize.command())
         .subcommand(self.config_set.command())
+        .subcommand(self.stop.command())
+        .subcommand(self.delete.command())
         .subcommand_required(true)
     }
 
@@ -54,6 +65,8 @@ impl CliCommand for InfraCommand {
             Some(("status", sub_matches)) => self.status.handler(sub_matches),
             Some(("resize", sub_matches)) => self.resize.handler(sub_matches),
             Some(("config-set", sub_matches)) => self.config_set.handler(sub_matches),
+            Some(("stop", sub_matches)) => self.stop.handler(sub_matches),
+            Some(("delete", sub_matches)) => self.delete.handler(sub_matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/infra/mod.rs
+++ b/cli/src/infra/mod.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod config_set;
+mod list;
+mod mutation;
+mod resize;
+mod resource_resolver;
+mod status;
+mod types;
+
+use config_set::ConfigSetCommand;
+use list::ListCommand;
+use resize::ResizeCommand;
+use status::StatusCommand;
+
+#[derive(Debug)]
+pub(crate) struct InfraCommand {
+    list: ListCommand,
+    status: StatusCommand,
+    resize: ResizeCommand,
+    config_set: ConfigSetCommand,
+}
+
+impl InfraCommand {
+    pub(crate) fn new() -> Self {
+        Self {
+            list: ListCommand::new(),
+            status: StatusCommand::new(),
+            resize: ResizeCommand::new(),
+            config_set: ConfigSetCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for InfraCommand {
+    fn command(&self) -> Command {
+        command(
+            "infra",
+            "Inspect and manage provisioned database, cache, and queue infrastructure",
+        )
+        .subcommand(self.list.command())
+        .subcommand(self.status.command())
+        .subcommand(self.resize.command())
+        .subcommand(self.config_set.command())
+        .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("list", sub_matches)) => self.list.handler(sub_matches),
+            Some(("status", sub_matches)) => self.status.handler(sub_matches),
+            Some(("resize", sub_matches)) => self.resize.handler(sub_matches),
+            Some(("config-set", sub_matches)) => self.config_set.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/infra/mutation.rs
+++ b/cli/src/infra/mutation.rs
@@ -1,0 +1,305 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use termcolor::{Color, ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    constants::{get_platform_ui_url, get_resource_management_api_url},
+    core::{
+        hmac::AuthMode,
+        http_client::{patch_with_auth, post_with_auth},
+    },
+    deploy::utils::stream_deployment_status,
+};
+
+use super::types::{
+    DeployResourceRequest, DeployResourceResponse, PatchResourceRequest, ResourceConfig,
+    ResourceDetailResponse,
+};
+
+/// Everything a mutating `fl infra` subcommand (`resize`, `config-set`) needs to
+/// apply a change: the target resource, what changed, and how to apply it.
+pub(crate) struct MutationRequest {
+    pub(crate) resource_id: String,
+    pub(crate) current: ResourceDetailResponse,
+    pub(crate) requested_config: ResourceConfig,
+    pub(crate) distribution_strategy: Option<String>,
+    pub(crate) primary_region: Option<String>,
+    pub(crate) snapshot_before_change: Option<bool>,
+    pub(crate) skip_confirm: bool,
+    pub(crate) dry_run: bool,
+}
+
+/// True if nothing was requested at all — no `ResourceConfig` field, no distribution
+/// strategy, no primary region. Callers should bail on this immediately, before any
+/// network call (resolving the resource, fetching its current detail), not after.
+pub(crate) fn nothing_to_change(
+    config: &ResourceConfig,
+    distribution_strategy: &Option<String>,
+    primary_region: &Option<String>,
+) -> bool {
+    is_metadata_only(config) && distribution_strategy.is_none() && primary_region.is_none()
+}
+
+/// True if the requested config has no `ResourceConfig` fields set at all — i.e. only
+/// `distribution_strategy`/`primary_region` (or nothing) changed, which routes through
+/// the cheaper synchronous `PATCH /:id` path instead of a full `POST /:id/deploy`.
+fn is_metadata_only(config: &ResourceConfig) -> bool {
+    let ResourceConfig {
+        instance_class,
+        engine,
+        allocated_storage,
+        num_cache_nodes,
+        number_of_broker_nodes,
+        ebs_storage_size,
+        visibility_timeout,
+        message_retention_seconds,
+        port,
+        multi_az,
+        node_type,
+        broker_node_type,
+        kafka_version,
+        queue_type,
+        encryption,
+    } = config;
+
+    instance_class.is_none()
+        && engine.is_none()
+        && allocated_storage.is_none()
+        && num_cache_nodes.is_none()
+        && number_of_broker_nodes.is_none()
+        && ebs_storage_size.is_none()
+        && visibility_timeout.is_none()
+        && message_retention_seconds.is_none()
+        && port.is_none()
+        && multi_az.is_none()
+        && node_type.is_none()
+        && broker_node_type.is_none()
+        && kafka_version.is_none()
+        && queue_type.is_none()
+        && encryption.is_none()
+}
+
+/// Prints every field that would change: `current value -> requested value`.
+fn print_config_diff(stdout: &mut StandardStream, current: &ResourceConfig, requested: &ResourceConfig) -> Result<()> {
+    writeln!(stdout, "  The following will change:")?;
+    macro_rules! diff_field {
+        ($label:expr, $cur:expr, $req:expr) => {
+            if let Some(new_value) = &$req {
+                writeln!(
+                    stdout,
+                    "    {:<24} {:?} -> {:?}",
+                    $label,
+                    $cur.as_ref().map(|v| format!("{:?}", v)).unwrap_or_else(|| "unset".to_string()),
+                    new_value
+                )?;
+            }
+        };
+    }
+    diff_field!("instance_class:", current.instance_class, requested.instance_class);
+    diff_field!("engine:", current.engine, requested.engine);
+    diff_field!("allocated_storage:", current.allocated_storage, requested.allocated_storage);
+    diff_field!("num_cache_nodes:", current.num_cache_nodes, requested.num_cache_nodes);
+    diff_field!("number_of_broker_nodes:", current.number_of_broker_nodes, requested.number_of_broker_nodes);
+    diff_field!("ebs_storage_size:", current.ebs_storage_size, requested.ebs_storage_size);
+    diff_field!("visibility_timeout:", current.visibility_timeout, requested.visibility_timeout);
+    diff_field!("message_retention_seconds:", current.message_retention_seconds, requested.message_retention_seconds);
+    diff_field!("port:", current.port, requested.port);
+    diff_field!("multi_az:", current.multi_az, requested.multi_az);
+    diff_field!("node_type:", current.node_type, requested.node_type);
+    diff_field!("broker_node_type:", current.broker_node_type, requested.broker_node_type);
+    diff_field!("kafka_version:", current.kafka_version, requested.kafka_version);
+    diff_field!("queue_type:", current.queue_type, requested.queue_type);
+    diff_field!("encryption:", current.encryption, requested.encryption);
+    Ok(())
+}
+
+/// Runs a mutation request end to end: prints the diff, gates on confirmation
+/// (skippable), routes to the cheap synchronous PATCH path when nothing but
+/// distribution metadata changed, otherwise calls `POST /deploy` and polls to
+/// completion — printing the dashboard URL before polling starts so a dropped
+/// connection never leaves the user unable to check on a live mutation.
+pub(crate) fn run_mutation(auth_mode: &AuthMode, req: MutationRequest) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    if is_metadata_only(&req.requested_config) {
+        if req.distribution_strategy.is_none() && req.primary_region.is_none() {
+            bail!("nothing to change — no fields were set");
+        }
+        if req.dry_run {
+            writeln!(stdout, "Dry run: would PATCH distributionStrategy/primaryRegion. No changes applied.")?;
+            return Ok(());
+        }
+        let updated = patch_resource(
+            auth_mode,
+            &req.resource_id,
+            req.distribution_strategy,
+            req.primary_region,
+        )?;
+        writeln!(stdout, "Updated {} (status: {})", updated.name, updated.status)?;
+        return Ok(());
+    }
+
+    writeln!(stdout)?;
+    print_config_diff(&mut stdout, &req.current.manifest_config, &req.requested_config)?;
+    writeln!(stdout)?;
+
+    if req.dry_run {
+        writeln!(stdout, "Dry run: no changes applied.")?;
+        return Ok(());
+    }
+
+    if !req.skip_confirm {
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Apply this change?")
+            .default(false)
+            .interact()
+            .with_context(|| "Failed to read confirmation")?;
+        if !confirmed {
+            writeln!(stdout, "Aborted — no changes applied.")?;
+            return Ok(());
+        }
+    }
+
+    let response = deploy_resource(
+        auth_mode,
+        &req.resource_id,
+        Some(req.requested_config),
+        req.distribution_strategy,
+        req.primary_region,
+        req.snapshot_before_change,
+    )?;
+
+    let dashboard_url = format!(
+        "{}/dashboard/deployments/{}",
+        get_platform_ui_url(),
+        response.deployment_id
+    );
+    writeln!(stdout)?;
+    stdout.set_color(termcolor::ColorSpec::new().set_fg(Some(Color::Green)))?;
+    writeln!(stdout, "Change submitted: {}", dashboard_url)?;
+    stdout.reset()?;
+    writeln!(stdout, "(Check this URL if the live status stream below is interrupted.)")?;
+    writeln!(stdout)?;
+
+    stream_deployment_status(auth_mode, &response.deployment_id, &mut stdout)?;
+
+    Ok(())
+}
+
+/// `POST /:id/deploy` — the unified endpoint backing both `resize` and `config-set`'s
+/// general path. A 409 means another operation is already in progress for this
+/// app/environment/region (the platform's deployment lock is scoped broader than the
+/// single resource) — surfaced as a clear retry message instead of the raw body.
+fn deploy_resource(
+    auth_mode: &AuthMode,
+    resource_id: &str,
+    manifest_config: Option<ResourceConfig>,
+    distribution_strategy: Option<String>,
+    primary_region: Option<String>,
+    snapshot_before_change: Option<bool>,
+) -> Result<DeployResourceResponse> {
+    let url = format!(
+        "{}/platform-resources/{}/deploy",
+        get_resource_management_api_url(),
+        resource_id
+    );
+
+    let body = DeployResourceRequest {
+        manifest_config,
+        distribution_strategy,
+        primary_region,
+        snapshot_before_change,
+    };
+
+    let response = post_with_auth(auth_mode, &url, serde_json::to_value(&body)?)
+        .with_context(|| "Failed to reach resource-management API")?;
+    let status = response.status();
+
+    if status.as_u16() == 409 {
+        bail!(
+            "another operation is already in progress for this application/environment/region — try again shortly"
+        );
+    }
+
+    if !status.is_success() {
+        let body_text = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        bail!("resource-management API returned {} — {}", status, body_text);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse deploy response")
+}
+
+/// `PATCH /:id` — synchronous, metadata-only (distribution strategy / primary region),
+/// no deployment row created, no polling needed. Confirmed against the platform's
+/// response schema (`ResourceDetailResponseSchema`, same shape as `GET /:resourceId`).
+fn patch_resource(
+    auth_mode: &AuthMode,
+    resource_id: &str,
+    distribution_strategy: Option<String>,
+    primary_region: Option<String>,
+) -> Result<ResourceDetailResponse> {
+    let url = format!(
+        "{}/platform-resources/{}",
+        get_resource_management_api_url(),
+        resource_id
+    );
+
+    let body = PatchResourceRequest {
+        distribution_strategy,
+        primary_region,
+    };
+
+    let response = patch_with_auth(auth_mode, &url, serde_json::to_value(&body)?)
+        .with_context(|| "Failed to reach resource-management API")?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body_text = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        bail!("resource-management API returned {} — {}", status, body_text);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse patch response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_only_true_when_all_config_fields_unset() {
+        assert!(is_metadata_only(&ResourceConfig::default()));
+    }
+
+    #[test]
+    fn nothing_to_change_true_when_everything_unset() {
+        assert!(nothing_to_change(&ResourceConfig::default(), &None, &None));
+    }
+
+    #[test]
+    fn nothing_to_change_false_when_distribution_strategy_set() {
+        assert!(!nothing_to_change(
+            &ResourceConfig::default(),
+            &Some("centralized".to_string()),
+            &None
+        ));
+    }
+
+    #[test]
+    fn metadata_only_false_when_any_config_field_set() {
+        let config = ResourceConfig {
+            instance_class: Some("db.t3.small".to_string()),
+            ..Default::default()
+        };
+        assert!(!is_metadata_only(&config));
+    }
+}

--- a/cli/src/infra/mutation.rs
+++ b/cli/src/infra/mutation.rs
@@ -13,9 +13,12 @@ use crate::{
     deploy::utils::stream_deployment_status,
 };
 
-use super::types::{
-    DeployResourceRequest, DeployResourceResponse, PatchResourceRequest, ResourceConfig,
-    ResourceDetailResponse,
+use super::{
+    resource_resolver::encode_resource_id_for_url,
+    types::{
+        DeployResourceRequest, DeployResourceResponse, PatchResourceRequest, ResourceConfig,
+        ResourceDetailResponse,
+    },
 };
 
 /// Everything a mutating `fl infra` subcommand (`resize`, `config-set`) needs to
@@ -87,11 +90,15 @@ fn print_config_diff(stdout: &mut StandardStream, current: &ResourceConfig, requ
     macro_rules! diff_field {
         ($label:expr, $cur:expr, $req:expr) => {
             if let Some(new_value) = &$req {
+                let cur_display = $cur
+                    .as_ref()
+                    .map(|v| format!("{:?}", v))
+                    .unwrap_or_else(|| "unset".to_string());
                 writeln!(
                     stdout,
-                    "    {:<24} {:?} -> {:?}",
+                    "    {:<24} {} -> {:?}",
                     $label,
-                    $cur.as_ref().map(|v| format!("{:?}", v)).unwrap_or_else(|| "unset".to_string()),
+                    cur_display,
                     new_value
                 )?;
             }
@@ -203,7 +210,7 @@ fn deploy_resource(
     let url = format!(
         "{}/platform-resources/{}/deploy",
         get_resource_management_api_url(),
-        resource_id
+        encode_resource_id_for_url(resource_id)
     );
 
     let body = DeployResourceRequest {
@@ -247,7 +254,7 @@ fn patch_resource(
     let url = format!(
         "{}/platform-resources/{}",
         get_resource_management_api_url(),
-        resource_id
+        encode_resource_id_for_url(resource_id)
     );
 
     let body = PatchResourceRequest {

--- a/cli/src/infra/resize.rs
+++ b/cli/src/infra/resize.rs
@@ -1,0 +1,161 @@
+use anyhow::{Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_integration, require_manifest, resolve_auth},
+    },
+};
+
+use super::{
+    mutation::{MutationRequest, nothing_to_change, run_mutation},
+    resource_resolver::{fetch_resource_detail, require_jwt_mode, resolve},
+    types::ResourceConfig,
+};
+
+#[derive(Debug)]
+pub(super) struct ResizeCommand;
+
+impl ResizeCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ResizeCommand {
+    fn command(&self) -> Command {
+        command(
+            "resize",
+            "Resize a provisioned database, cache, or queue resource",
+        )
+        .arg(
+            Arg::new("resource")
+                .help("Resource identifier: <project-name>:<resource-type> (e.g. billing-service:database)")
+                .required(true),
+        )
+        .arg(Arg::new("base_path").short('p').long("path").help("The application path"))
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to target (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("resource_id")
+                .long("resource-id")
+                .help("Skip name resolution and address a resource by its platform id directly"),
+        )
+        .arg(
+            Arg::new("instance_class")
+                .long("instance-class")
+                .help("Database instance class (e.g. db.t3.small)"),
+        )
+        .arg(
+            Arg::new("allocated_storage")
+                .long("allocated-storage")
+                .value_parser(clap::value_parser!(u32))
+                .help("Allocated storage in GB (database)"),
+        )
+        .arg(Arg::new("node_type").long("node-type").help("Cache node type"))
+        .arg(
+            Arg::new("num_cache_nodes")
+                .long("num-cache-nodes")
+                .value_parser(clap::value_parser!(u32))
+                .help("Number of cache nodes"),
+        )
+        .arg(
+            Arg::new("number_of_broker_nodes")
+                .long("number-of-broker-nodes")
+                .value_parser(clap::value_parser!(u32))
+                .help("Number of broker nodes (queue)"),
+        )
+        .arg(
+            Arg::new("ebs_storage_size")
+                .long("ebs-storage-size")
+                .value_parser(clap::value_parser!(u32))
+                .help("EBS storage size in GB (queue)"),
+        )
+        .arg(
+            Arg::new("snapshot_before_change")
+                .long("snapshot-before-change")
+                .help("Take a snapshot before applying the change (database)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .help("Skip the confirmation prompt (for CI/scripted use)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("dry_run")
+                .long("dry-run")
+                .help("Print the change without applying it")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_auth()?;
+        require_jwt_mode(&auth_mode)?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("--environment is required")
+            .to_string();
+        let resource_arg = matches
+            .get_one::<String>("resource")
+            .expect("<resource> is required");
+        let resource_id_override = matches.get_one::<String>("resource_id").map(String::as_str);
+
+        let requested_config = ResourceConfig {
+            instance_class: matches.get_one::<String>("instance_class").cloned(),
+            allocated_storage: matches.get_one::<u32>("allocated_storage").copied(),
+            node_type: matches.get_one::<String>("node_type").cloned(),
+            num_cache_nodes: matches.get_one::<u32>("num_cache_nodes").copied(),
+            number_of_broker_nodes: matches.get_one::<u32>("number_of_broker_nodes").copied(),
+            ebs_storage_size: matches.get_one::<u32>("ebs_storage_size").copied(),
+            ..Default::default()
+        };
+
+        // Fail before any network call — resolving the resource and fetching its
+        // current detail are both wasted if there's nothing to change.
+        if nothing_to_change(&requested_config, &None, &None) {
+            bail!("nothing to change — pass at least one sizing flag");
+        }
+
+        let resolved = resolve(
+            &auth_mode,
+            &manifest,
+            &application_id,
+            &environment,
+            resource_arg,
+            resource_id_override,
+        )?;
+
+        let current = fetch_resource_detail(&auth_mode, &resolved.id)?;
+
+        run_mutation(
+            &auth_mode,
+            MutationRequest {
+                resource_id: resolved.id,
+                current,
+                requested_config,
+                distribution_strategy: None,
+                primary_region: None,
+                snapshot_before_change: if matches.get_flag("snapshot_before_change") {
+                    Some(true)
+                } else {
+                    None
+                },
+                skip_confirm: matches.get_flag("yes"),
+                dry_run: matches.get_flag("dry_run"),
+            },
+        )
+    }
+}

--- a/cli/src/infra/resource_resolver.rs
+++ b/cli/src/infra/resource_resolver.rs
@@ -1,0 +1,245 @@
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::{
+    constants::get_resource_management_api_url,
+    core::{hmac::AuthMode, http_client::get_with_auth, manifest::application::ApplicationManifestData},
+};
+
+use super::types::{ResourceDetailResponse, ResourceListItem};
+
+/// `fl infra` is JWT/session-only in v1 — resource-management's routes have no HMAC
+/// support (`AccessLevel` forbids RBAC on `internal`-only routes, so adding it would
+/// give any HMAC-secret holder unrestricted mutate access). CI/automation support is
+/// tracked as a v2 item in TODOS.md, not attempted here.
+pub(crate) fn require_jwt_mode(auth_mode: &AuthMode) -> Result<()> {
+    if auth_mode.is_hmac() {
+        bail!(
+            "fl infra commands are not supported in CI/HMAC mode yet — JWT/session auth is required. \
+             See TODOS.md for CI support tracking."
+        );
+    }
+    Ok(())
+}
+
+/// Maps the CLI's friendly resource-type token (matching `ResourceInventory`'s field
+/// names) to the platform's exact `IntegrationType` string.
+pub(crate) fn resource_type_to_integration_type(token: &str) -> Result<&'static str> {
+    match token {
+        "database" => Ok("database"),
+        "cache" => Ok("cache"),
+        "queue" => Ok("messagequeue"),
+        "object-store" => Ok("objectstore"),
+        other => Err(anyhow!(
+            "unknown resource type '{other}' — expected one of: database, cache, queue, object-store"
+        )),
+    }
+}
+
+/// Fetches every provisioned resource for the application in a given environment.
+/// Shared by `fl infra list` and every resolving subcommand — do not duplicate this
+/// call elsewhere; both call sites must stay on this one function.
+pub(crate) fn fetch_application_resources(
+    auth_mode: &AuthMode,
+    application_id: &str,
+    environment: &str,
+) -> Result<Vec<ResourceListItem>> {
+    let url = format!(
+        "{}/platform-resources/application/{}?environment={}",
+        get_resource_management_api_url(),
+        application_id,
+        environment
+    );
+
+    let response = get_with_auth(auth_mode, &url)
+        .with_context(|| "Failed to reach resource-management API")?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        bail!("resource-management API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse resource list response")
+}
+
+/// Fetches the full detail (including `manifestConfig`) for a resolved resource id.
+/// Shared by `status`'s full view, `status --config`'s narrower view, and the
+/// mutation commands' pre-change diff — all are the same underlying `GET
+/// /:resourceId` call, differing only in what they do with the result.
+pub(crate) fn fetch_resource_detail(
+    auth_mode: &AuthMode,
+    resource_id: &str,
+) -> Result<ResourceDetailResponse> {
+    let url = format!(
+        "{}/platform-resources/{}",
+        get_resource_management_api_url(),
+        resource_id
+    );
+
+    let response =
+        get_with_auth(auth_mode, &url).with_context(|| "Failed to reach resource-management API")?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        bail!("resource-management API returned {} — {}", status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse resource detail response")
+}
+
+/// A resolved `<project>:<type>` identifier, ready to address a specific platform
+/// resource.
+pub(crate) struct ResolvedResource {
+    pub(crate) id: String,
+    pub(crate) project_name: String,
+    pub(crate) resource_type: String,
+}
+
+/// Resolves a `<project-name>:<resource-type>` identifier (or an explicit
+/// `--resource-id` override) to a concrete platform resource id.
+///
+/// Order: parse the token (no network) -> confirm the manifest actually configures
+/// that resource for that project (no network) -> fetch and filter against the
+/// platform's live resource list (network) -> disambiguate.
+pub(crate) fn resolve(
+    auth_mode: &AuthMode,
+    manifest: &ApplicationManifestData,
+    application_id: &str,
+    environment: &str,
+    resource_arg: &str,
+    resource_id_override: Option<&str>,
+) -> Result<ResolvedResource> {
+    let (project_name, resource_type) = resource_arg
+        .split_once(':')
+        .ok_or_else(|| anyhow!("expected '<project-name>:<resource-type>', got '{resource_arg}'"))?;
+
+    let mapped_type = resource_type_to_integration_type(resource_type)?;
+
+    if let Some(id) = resource_id_override {
+        return Ok(ResolvedResource {
+            id: id.to_string(),
+            project_name: project_name.to_string(),
+            resource_type: resource_type.to_string(),
+        });
+    }
+
+    let project = manifest
+        .projects
+        .iter()
+        .find(|p| p.name == project_name)
+        .ok_or_else(|| anyhow!("project '{project_name}' not found in manifest.toml"))?;
+
+    let configured = project.resources.as_ref().map_or(false, |r| match resource_type {
+        "database" => r.database.is_some(),
+        "cache" => r.cache.is_some(),
+        "queue" => r.queue.is_some(),
+        "object-store" => r.object_store.is_some(),
+        _ => false,
+    });
+
+    if !configured {
+        bail!(
+            "project '{project_name}' has no '{resource_type}' resource configured in manifest.toml"
+        );
+    }
+
+    let resources = fetch_application_resources(auth_mode, application_id, environment)?;
+    let matches: Vec<&ResourceListItem> = resources
+        .iter()
+        .filter(|r| {
+            r.service_name.as_deref() == Some(project_name) && r.r#type == mapped_type
+        })
+        .collect();
+
+    match matches.len() {
+        0 => {
+            let available = resources
+                .iter()
+                .map(|r| format!("{}:{}", r.service_name.as_deref().unwrap_or("?"), r.r#type))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "no '{resource_type}' resource found for project '{project_name}' in environment '{environment}'. \
+                 Available resources: {}",
+                if available.is_empty() { "none".to_string() } else { available }
+            );
+        }
+        1 => Ok(ResolvedResource {
+            id: matches[0].id.clone(),
+            project_name: project_name.to_string(),
+            resource_type: resource_type.to_string(),
+        }),
+        _ => {
+            let candidates = matches
+                .iter()
+                .map(|r| {
+                    format!(
+                        "  id={} region={} status={}",
+                        r.id,
+                        r.region.as_deref().unwrap_or("?"),
+                        r.status
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            bail!(
+                "multiple '{resource_type}' resources found for project '{project_name}':\n{}\n\
+                 Use --resource-id <id> to disambiguate.",
+                candidates
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_jwt_mode_allows_jwt() {
+        assert!(require_jwt_mode(&AuthMode::Jwt).is_ok());
+    }
+
+    #[test]
+    fn require_jwt_mode_rejects_hmac() {
+        let hmac = AuthMode::Hmac {
+            secret_key: "test".to_string(),
+        };
+        let err = require_jwt_mode(&hmac).unwrap_err();
+        assert!(err.to_string().contains("CI/HMAC mode"));
+    }
+
+    #[test]
+    fn resource_type_maps_all_known_tokens() {
+        assert_eq!(resource_type_to_integration_type("database").unwrap(), "database");
+        assert_eq!(resource_type_to_integration_type("cache").unwrap(), "cache");
+        assert_eq!(resource_type_to_integration_type("queue").unwrap(), "messagequeue");
+        assert_eq!(
+            resource_type_to_integration_type("object-store").unwrap(),
+            "objectstore"
+        );
+    }
+
+    #[test]
+    fn resource_type_rejects_unknown_token() {
+        let err = resource_type_to_integration_type("bogus").unwrap_err();
+        assert!(err.to_string().contains("unknown resource type"));
+    }
+
+    #[test]
+    fn resource_type_rejects_raw_platform_string() {
+        // "queue" (CLI-facing) maps to "messagequeue" (platform) — the raw platform
+        // string itself should not also be accepted as a CLI-facing token, to avoid
+        // two spellings meaning the same thing.
+        assert!(resource_type_to_integration_type("messagequeue").is_err());
+    }
+}

--- a/cli/src/infra/resource_resolver.rs
+++ b/cli/src/infra/resource_resolver.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, anyhow, bail};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
 use crate::{
     constants::get_resource_management_api_url,
@@ -6,6 +7,34 @@ use crate::{
 };
 
 use super::types::{ResourceDetailResponse, ResourceListItem};
+
+/// Characters that must be escaped in a URL path segment. Letters, digits, and the
+/// unreserved punctuation used by UUIDs (`-`, `_`, `.`, `~`) are left untouched, so
+/// normal platform-resolved ids are byte-for-byte unchanged. Only characters that
+/// would otherwise restructure the request (`/`, `?`, `#`, `%`, whitespace, etc.)
+/// get encoded.
+const PATH_SEGMENT: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}');
+
+/// Percent-encodes a resource id before it's interpolated into a URL path segment.
+/// Every `.../platform-resources/{resource_id}...` URL must go through this — the id
+/// can come from the platform (always a clean UUID, effectively a no-op here) or
+/// from the user-supplied `--resource-id` escape hatch, which is unvalidated input
+/// and must not be trusted as URL structure (a value containing `/`, `?`, `#`, or
+/// `..` should stay opaque data, not alter the request path).
+pub(crate) fn encode_resource_id_for_url(resource_id: &str) -> String {
+    utf8_percent_encode(resource_id, PATH_SEGMENT).to_string()
+}
 
 /// `fl infra` is JWT/session-only in v1 — resource-management's routes have no HMAC
 /// support (`AccessLevel` forbids RBAC on `internal`-only routes, so adding it would
@@ -77,7 +106,7 @@ pub(crate) fn fetch_resource_detail(
     let url = format!(
         "{}/platform-resources/{}",
         get_resource_management_api_url(),
-        resource_id
+        encode_resource_id_for_url(resource_id)
     );
 
     let response =
@@ -241,5 +270,26 @@ mod tests {
         // string itself should not also be accepted as a CLI-facing token, to avoid
         // two spellings meaning the same thing.
         assert!(resource_type_to_integration_type("messagequeue").is_err());
+    }
+
+    #[test]
+    fn encode_resource_id_is_a_no_op_for_a_normal_uuid() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        assert_eq!(encode_resource_id_for_url(uuid), uuid);
+    }
+
+    #[test]
+    fn encode_resource_id_escapes_path_separator() {
+        assert_eq!(
+            encode_resource_id_for_url("abc/../secret"),
+            "abc%2F..%2Fsecret"
+        );
+    }
+
+    #[test]
+    fn encode_resource_id_escapes_query_and_fragment_markers() {
+        let encoded = encode_resource_id_for_url("id?environment=prod#frag");
+        assert!(!encoded.contains('?'));
+        assert!(!encoded.contains('#'));
     }
 }

--- a/cli/src/infra/status.rs
+++ b/cli/src/infra/status.rs
@@ -1,0 +1,177 @@
+use std::io::Write;
+
+use anyhow::Result;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_integration, require_manifest, resolve_auth},
+    },
+};
+
+use super::{
+    resource_resolver::{fetch_resource_detail, require_jwt_mode, resolve},
+    types::ResourceDetailResponse,
+};
+
+#[derive(Debug)]
+pub(super) struct StatusCommand;
+
+impl StatusCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for StatusCommand {
+    fn command(&self) -> Command {
+        command(
+            "status",
+            "Show the status of a provisioned database, cache, or queue resource",
+        )
+        .arg(
+            Arg::new("resource")
+                .help("Resource identifier: <project-name>:<resource-type> (e.g. billing-service:database)")
+                .required(true),
+        )
+        .arg(
+            Arg::new("base_path")
+                .short('p')
+                .long("path")
+                .help("The application path"),
+        )
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment to inspect (for example: dev, staging, production)"),
+        )
+        .arg(
+            Arg::new("resource_id")
+                .long("resource-id")
+                .help("Skip name resolution and address a resource by its platform id directly"),
+        )
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .help("Show only the resource's configuration (manifestConfig), not the full status view")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_auth()?;
+        require_jwt_mode(&auth_mode)?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("--environment is required")
+            .to_string();
+        let resource_arg = matches
+            .get_one::<String>("resource")
+            .expect("<resource> is required");
+        let resource_id_override = matches.get_one::<String>("resource_id").map(String::as_str);
+        let config_only = matches.get_flag("config");
+        let json_output = matches.get_flag("json");
+
+        let resolved = resolve(
+            &auth_mode,
+            &manifest,
+            &application_id,
+            &environment,
+            resource_arg,
+            resource_id_override,
+        )?;
+
+        let detail = fetch_resource_detail(&auth_mode, &resolved.id)?;
+
+        if json_output {
+            if config_only {
+                println!("{}", serde_json::to_string_pretty(&detail.manifest_config)?);
+            } else {
+                println!("{}", serde_json::to_string_pretty(&detail)?);
+            }
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        if config_only {
+            print_config(&mut stdout, &detail)?;
+        } else {
+            print_status(&mut stdout, &detail)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn print_status(stdout: &mut StandardStream, detail: &ResourceDetailResponse) -> Result<()> {
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+    writeln!(stdout, "{} ({})", detail.name, detail.r#type)?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    writeln!(stdout, "  id:           {}", detail.id)?;
+    writeln!(stdout, "  status:       {}", detail.status)?;
+    writeln!(stdout, "  provider:     {}", detail.provider)?;
+    if let Some(env) = &detail.environment {
+        writeln!(stdout, "  environment:  {}", env)?;
+    }
+    if let Some(region) = &detail.region {
+        writeln!(stdout, "  region:       {}", region)?;
+    }
+    if let Some(endpoint) = &detail.endpoint {
+        writeln!(stdout, "  endpoint:     {}", endpoint)?;
+    }
+    writeln!(stdout, "  updated:      {}", detail.updated_at)?;
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn print_config(stdout: &mut StandardStream, detail: &ResourceDetailResponse) -> Result<()> {
+    writeln!(stdout)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+    writeln!(stdout, "{} — configuration", detail.name)?;
+    stdout.reset()?;
+    writeln!(stdout)?;
+
+    let cfg = &detail.manifest_config;
+    macro_rules! print_field {
+        ($label:expr, $value:expr) => {
+            if let Some(v) = &$value {
+                writeln!(stdout, "  {:<20} {:?}", $label, v)?;
+            }
+        };
+    }
+    print_field!("instance_class:", cfg.instance_class);
+    print_field!("engine:", cfg.engine);
+    print_field!("allocated_storage:", cfg.allocated_storage);
+    print_field!("num_cache_nodes:", cfg.num_cache_nodes);
+    print_field!("number_of_broker_nodes:", cfg.number_of_broker_nodes);
+    print_field!("ebs_storage_size:", cfg.ebs_storage_size);
+    print_field!("visibility_timeout:", cfg.visibility_timeout);
+    print_field!("message_retention_seconds:", cfg.message_retention_seconds);
+    print_field!("port:", cfg.port);
+    print_field!("multi_az:", cfg.multi_az);
+    print_field!("node_type:", cfg.node_type);
+    print_field!("broker_node_type:", cfg.broker_node_type);
+    print_field!("kafka_version:", cfg.kafka_version);
+    print_field!("queue_type:", cfg.queue_type);
+    print_field!("encryption:", cfg.encryption);
+    writeln!(stdout)?;
+
+    Ok(())
+}

--- a/cli/src/infra/stop.rs
+++ b/cli/src/infra/stop.rs
@@ -1,0 +1,103 @@
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use dialoguer::{Confirm, theme::ColorfulTheme};
+
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_integration, require_manifest, resolve_auth},
+    },
+};
+
+use super::{
+    lifecycle::call_lifecycle_action,
+    resource_resolver::{fetch_resource_detail, require_jwt_mode, resolve},
+};
+
+#[derive(Debug)]
+pub(super) struct StopCommand;
+
+impl StopCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for StopCommand {
+    fn command(&self) -> Command {
+        command("stop", "Stop a provisioned database, cache, or queue resource")
+            .arg(
+                Arg::new("resource")
+                    .help("Resource identifier: <project-name>:<resource-type> (e.g. billing-service:database)")
+                    .required(true),
+            )
+            .arg(Arg::new("base_path").short('p').long("path").help("The application path"))
+            .arg(
+                Arg::new("environment")
+                    .short('e')
+                    .long("environment")
+                    .required(true)
+                    .help("Environment to target (for example: dev, staging, production)"),
+            )
+            .arg(
+                Arg::new("resource_id")
+                    .long("resource-id")
+                    .help("Skip name resolution and address a resource by its platform id directly"),
+            )
+            .arg(
+                Arg::new("yes")
+                    .long("yes")
+                    .short('y')
+                    .help("Skip the confirmation prompt (for CI/scripted use)")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_auth()?;
+        require_jwt_mode(&auth_mode)?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("--environment is required")
+            .to_string();
+        let resource_arg = matches
+            .get_one::<String>("resource")
+            .expect("<resource> is required");
+        let resource_id_override = matches.get_one::<String>("resource_id").map(String::as_str);
+        let skip_confirm = matches.get_flag("yes");
+
+        let resolved = resolve(
+            &auth_mode,
+            &manifest,
+            &application_id,
+            &environment,
+            resource_arg,
+            resource_id_override,
+        )?;
+
+        let detail = fetch_resource_detail(&auth_mode, &resolved.id)?;
+
+        if !skip_confirm {
+            let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!(
+                    "Stop {} ({})? This may cause downtime for anything depending on it.",
+                    detail.name, detail.r#type
+                ))
+                .default(false)
+                .interact()
+                .with_context(|| "Failed to read confirmation")?;
+            if !confirmed {
+                println!("Aborted — resource not stopped.");
+                return Ok(());
+            }
+        }
+
+        let result = call_lifecycle_action(&auth_mode, &resolved.id, "stop")?;
+        println!("{}", result.message);
+
+        Ok(())
+    }
+}

--- a/cli/src/infra/types.rs
+++ b/cli/src/infra/types.rs
@@ -120,6 +120,12 @@ pub(crate) struct DeployResourceResponse {
     pub(crate) deployment_id: String,
 }
 
+/// `POST /:id/stop` and `POST /:id/delete` both respond with this synchronous shape.
+#[derive(Debug, Deserialize)]
+pub(crate) struct MessageResponse {
+    pub(crate) message: String,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct PatchResourceRequest {
     #[serde(

--- a/cli/src/infra/types.rs
+++ b/cli/src/infra/types.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+
+/// One entry from `GET /platform-resources/application/:applicationId`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ResourceListItem {
+    pub(crate) id: String,
+    #[serde(rename = "type")]
+    pub(crate) r#type: String,
+    #[serde(rename = "technology")]
+    pub(crate) technology: Option<String>,
+    #[serde(rename = "provider")]
+    pub(crate) provider: Option<String>,
+    #[serde(rename = "serviceId")]
+    pub(crate) service_id: Option<String>,
+    #[serde(rename = "serviceName")]
+    pub(crate) service_name: Option<String>,
+    pub(crate) environment: Option<String>,
+    pub(crate) region: Option<String>,
+    pub(crate) status: String,
+    #[serde(rename = "resourceId")]
+    pub(crate) resource_id: Option<String>,
+    pub(crate) endpoint: Option<String>,
+}
+
+/// `manifestConfig` shape — `ResourceConfigSchema` on the platform. All fields optional;
+/// covers both "resize" (instanceClass/allocatedStorage/nodeType/...) and "config-set"
+/// (engine/multiAZ/queueType/...) use cases, since the platform makes no distinction.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct ResourceConfig {
+    #[serde(rename = "instanceClass", skip_serializing_if = "Option::is_none")]
+    pub(crate) instance_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) engine: Option<String>,
+    #[serde(rename = "allocatedStorage", skip_serializing_if = "Option::is_none")]
+    pub(crate) allocated_storage: Option<u32>,
+    #[serde(rename = "numCacheNodes", skip_serializing_if = "Option::is_none")]
+    pub(crate) num_cache_nodes: Option<u32>,
+    #[serde(
+        rename = "numberOfBrokerNodes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) number_of_broker_nodes: Option<u32>,
+    #[serde(rename = "ebsStorageSize", skip_serializing_if = "Option::is_none")]
+    pub(crate) ebs_storage_size: Option<u32>,
+    #[serde(rename = "visibilityTimeout", skip_serializing_if = "Option::is_none")]
+    pub(crate) visibility_timeout: Option<u32>,
+    #[serde(
+        rename = "messageRetentionSeconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) message_retention_seconds: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) port: Option<u16>,
+    #[serde(rename = "multiAZ", skip_serializing_if = "Option::is_none")]
+    pub(crate) multi_az: Option<bool>,
+    #[serde(rename = "nodeType", skip_serializing_if = "Option::is_none")]
+    pub(crate) node_type: Option<String>,
+    #[serde(rename = "brokerNodeType", skip_serializing_if = "Option::is_none")]
+    pub(crate) broker_node_type: Option<String>,
+    #[serde(rename = "kafkaVersion", skip_serializing_if = "Option::is_none")]
+    pub(crate) kafka_version: Option<String>,
+    #[serde(rename = "queueType", skip_serializing_if = "Option::is_none")]
+    pub(crate) queue_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) encryption: Option<String>,
+}
+
+/// `GET /platform-resources/:resourceId` response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ResourceDetailResponse {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    #[serde(rename = "type")]
+    pub(crate) r#type: String,
+    pub(crate) provider: String,
+    #[serde(rename = "distributionStrategy")]
+    pub(crate) distribution_strategy: String,
+    pub(crate) status: String,
+    #[serde(rename = "createdAt")]
+    pub(crate) created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub(crate) updated_at: String,
+    pub(crate) environment: Option<String>,
+    pub(crate) region: Option<String>,
+    #[serde(rename = "primaryRegion")]
+    pub(crate) primary_region: Option<String>,
+    #[serde(rename = "resourceId")]
+    pub(crate) resource_id: Option<String>,
+    pub(crate) arn: Option<String>,
+    pub(crate) endpoint: Option<String>,
+    #[serde(rename = "serviceId")]
+    pub(crate) service_id: Option<String>,
+    #[serde(rename = "serviceName")]
+    pub(crate) service_name: Option<String>,
+    #[serde(rename = "manifestConfig")]
+    pub(crate) manifest_config: ResourceConfig,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct DeployResourceRequest {
+    #[serde(rename = "manifestConfig", skip_serializing_if = "Option::is_none")]
+    pub(crate) manifest_config: Option<ResourceConfig>,
+    #[serde(
+        rename = "distributionStrategy",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) distribution_strategy: Option<String>,
+    #[serde(rename = "primaryRegion", skip_serializing_if = "Option::is_none")]
+    pub(crate) primary_region: Option<String>,
+    #[serde(
+        rename = "snapshotBeforeChange",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) snapshot_before_change: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DeployResourceResponse {
+    #[serde(rename = "deploymentId")]
+    pub(crate) deployment_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PatchResourceRequest {
+    #[serde(
+        rename = "distributionStrategy",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) distribution_strategy: Option<String>,
+    #[serde(rename = "primaryRegion", skip_serializing_if = "Option::is_none")]
+    pub(crate) primary_region: Option<String>,
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,7 @@ use depcheck::DepcheckCommand;
 use deploy::DeployCommand;
 use eject::EjectCommand;
 use environment::EnvironmentCommand;
+use infra::InfraCommand;
 use init::InitCommand;
 use integrate::IntegrateCommand;
 use login::LoginCommand;
@@ -36,6 +37,7 @@ mod depcheck;
 mod deploy;
 mod eject;
 mod environment;
+mod infra;
 mod init;
 mod integrate;
 mod login;
@@ -67,6 +69,7 @@ fn main() -> Result<()> {
     let deploy = DeployCommand::new();
     let eject = EjectCommand::new();
     let environment = EnvironmentCommand::new();
+    let infra = InfraCommand::new();
     let integrate = IntegrateCommand::new();
     let login = LoginCommand::new();
     let logout = LogoutCommand::new();
@@ -93,6 +96,7 @@ fn main() -> Result<()> {
         .subcommand(context.command())
         .subcommand(deploy.command())
         .subcommand(environment.command())
+        .subcommand(infra.command())
         .subcommand(integrate.command())
         .subcommand(openapi.command())
         .subcommand(release.command())
@@ -121,6 +125,7 @@ fn main() -> Result<()> {
         Some(("deploy", sub_matches)) => deploy.handler(sub_matches),
         Some(("eject", sub_matches)) => eject.handler(sub_matches),
         Some(("environment", sub_matches)) => environment.handler(sub_matches),
+        Some(("infra", sub_matches)) => infra.handler(sub_matches),
         Some(("integrate", sub_matches)) => integrate.handler(sub_matches),
         Some(("openapi", sub_matches)) => openapi.handler(sub_matches),
         Some(("release", sub_matches)) => release.handler(sub_matches),


### PR DESCRIPTION
## Summary
- Adds `fl infra` command group: `list`, `status` (with `--config`), `resize`, `config-set`, `stop`, `delete`
- Wires up existing `resource-management` platform APIs — no new platform routes needed for any of these six commands
- `fl infra creds` is not included yet; needs a new platform-side proxy route and a security sign-off on role gating
- Also fixes two issues from CodeRabbit review: unescaped `--resource-id` interpolated into URL paths, and double-formatted "current" values in the resize/config-set confirmation diff

## Test plan
- `cargo test` — 327 passing, no regressions
- Manual verification of resolution/validation paths (parse errors, manifest checks, confirm gating) against local scaffolding
- End-to-end mutation/lifecycle paths (`resize`/`config-set`/`stop`/`delete` against a real resource) still need a staging environment with a provisioned resource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `infra` CLI with `list`, `status`, `resize`, `config-set`, `stop`, and `delete`.
  * Added resource configuration/deployment flows including dry-run, confirmation, snapshot-before-change, and distribution/region options.
* **Bug Fixes**
  * Improved authenticated request headers (JSON `Accept` + CLI `User-Agent`) and added authenticated PATCH support.
  * Unknown deployment phases now safely fall back to the raw phase text.
* **Chores**
  * Updated local ignore rules to include `.gstack`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->