### PR TITLE
release/cli-1.3.2: deterministic compliance-audit field order

### DIFF
--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -115,7 +115,7 @@ impl CliCommand for AuditCommand {
         let entities: Vec<EntityReport> = entity_names
             .into_iter()
             .map(|name| {
-                let field_reports: Vec<FieldReport> = field_classifications
+                let mut field_reports: Vec<FieldReport> = field_classifications
                     .get(&name)
                     .map(|fields| {
                         fields
@@ -129,6 +129,9 @@ impl CliCommand for AuditCommand {
                             .collect()
                     })
                     .unwrap_or_default();
+                // `field_classifications` is a HashMap, so its fields iterate in a non-deterministic
+                // order — sort by name so the report (and `--json`) is byte-stable for the same code.
+                field_reports.sort_by(|a, b| a.name.cmp(&b.name));
                 let retention =
                     retention_policies.get(&name).map(|r| RetentionReport {
                         duration: r.duration.clone(),


### PR DESCRIPTION
Patch cli-v1.3.2. Sorts per-entity audit fields by name so `compliance audit --json` is byte-stable for the same code (was HashMap-ordered). Verified byte-identical across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized the ordering of fields in audit reports.
  * Ensured JSON output remains consistent and reproducible across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->