### PR TITLE
fix(cli): fl infra list fails to parse resource-management response

### DIFF
--- a/cli/src/infra/resource_resolver.rs
+++ b/cli/src/infra/resource_resolver.rs
@@ -6,7 +6,7 @@ use crate::{
     core::{hmac::AuthMode, http_client::get_with_auth, manifest::application::ApplicationManifestData},
 };
 
-use super::types::{ResourceDetailResponse, ResourceListItem};
+use super::types::{ApplicationResourcesResponse, ResourceDetailResponse, ResourceListItem};
 
 /// Characters that must be escaped in a URL path segment. Letters, digits, and the
 /// unreserved punctuation used by UUIDs (`-`, `_`, `.`, `~`) are left untouched, so
@@ -90,9 +90,10 @@ pub(crate) fn fetch_application_resources(
         bail!("resource-management API returned {} — {}", status, body);
     }
 
-    response
+    let parsed: ApplicationResourcesResponse = response
         .json()
-        .with_context(|| "Failed to parse resource list response")
+        .with_context(|| "Failed to parse resource list response")?;
+    Ok(parsed.resources)
 }
 
 /// Fetches the full detail (including `manifestConfig`) for a resolved resource id.

--- a/cli/src/infra/types.rs
+++ b/cli/src/infra/types.rs
@@ -22,6 +22,11 @@ pub(crate) struct ResourceListItem {
     pub(crate) endpoint: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApplicationResourcesResponse {
+    pub(crate) resources: Vec<ResourceListItem>,
+}
+
 /// `manifestConfig` shape — `ResourceConfigSchema` on the platform. All fields optional;
 /// covers both "resize" (instanceClass/allocatedStorage/nodeType/...) and "config-set"
 /// (engine/multiAZ/queueType/...) use cases, since the platform makes no distinction.


### PR DESCRIPTION
## Summary

`fl infra list` (and every command that resolves a `<project>:<type>` identifier — `status`/`resize`/`config-set`/`stop`/`delete`, since they all share the same fetch call) was deserializing `GET /platform-resources/application/:applicationId`'s response body directly into a bare array. The platform's actual response schema wraps the array under a `resources` key (`{"resources": [...]}`, per `ApplicationResourcesResponseSchema`), so every real call failed with:

```
Error: Failed to parse resource list response
Caused by:
  invalid type: map, expected a sequence
```

This went uncaught during the original build since testing only got as far as connection-level checks against the resource-management API, never a real parsed response.

## Fix

- Added `ApplicationResourcesResponse { resources: Vec<ResourceListItem> }` to model the actual wrapped shape.
- `fetch_application_resources()` now deserializes into that wrapper and returns `.resources`, instead of assuming a bare array.

No platform-side changes — purely a client-side deserialization fix.

## Test plan

- [x] `cargo build` + existing `infra::` unit tests pass
- [x] Verified live against a real staging application: `fl infra list`, `fl infra status <resource>` (including `--config` and `--json`), and `fl infra resize`/`config-set --dry-run` all now parse and render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of application resource list responses.
  * Resource listings are now parsed more reliably, helping ensure all available resources are returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->