### PR TITLE
fix(cli): stop deep-cloning cached subtrees in ImportScanner (exponential OOM)

### DIFF
--- a/cli/src/core/library_scanner.rs
+++ b/cli/src/core/library_scanner.rs
@@ -405,9 +405,28 @@ impl ImportScanner {
             }
         }
 
-        // Return cached result if this file was already fully scanned (DAG dedup)
+        // Return a SHALLOW stub if this file was already fully scanned (DAG dedup).
+        //
+        // Deep-cloning the cached subtree here (`cached.clone()`) is an
+        // accidental combinatorial explosion: in a diamond-heavy import graph
+        // every importer of a shared hub embeds a full copy of the hub's
+        // entire transitive subtree, materializing the DAG as an
+        // exponentially-sized tree. On a large monorepo this alone allocated
+        // >12 GB and OOM-killed `release create` inside the 16 GB deployment
+        // worker. `flatten_topology` dedups by visited path and early-returns
+        // on repeat encounters, so those embedded copies were pure waste — a
+        // childless stub is behavior-identical: the first (in-tree) occurrence
+        // carries the full subtree, later occurrences only need the node
+        // identity.
         if let Some(cached) = self.result_cache.get(file_path) {
-            return Ok(cached.clone());
+            return Ok(CodeNode {
+                name: cached.name.clone(),
+                node_type: cached.node_type.clone(),
+                version: cached.version.clone(),
+                children: None,
+                path: cached.path.clone(),
+                target_service: cached.target_service.clone(),
+            });
         }
 
         // Circular dependency check (file is currently being scanned in this call stack)


### PR DESCRIPTION
## Problem

`release create` was OOM-killed (`exited with code null` = SIGKILL) inside the 16GB deployment worker on a large customer monorepo (Frontera), failing every autodeploy **before CodeBuild was ever reached**. CloudWatch showed the worker going 6% → 99.4% memory within ~90s of each attempt.

Symbolized profiling (`sample` on a debug-info build) pinned it:

```
generate_release_manifest
  → ImportScanner::scan → scan_node
    → CodeNode::clone            ← 48% of all samples
      → Vec<CodeNode>::clone → … (10+ levels of recursive clone)
```

The DAG-dedup cache in `scan_node` returned **`cached.clone()` — a deep clone of the node's entire transitive subtree**. In a diamond-heavy import graph, every importer of a shared hub embeds a full copy of the hub's whole tree, materializing the DAG as an exponentially-sized tree. The CLI process alone reached a 12.1GB footprint on macOS (>16GB on Linux).

## Fix

Return a **childless stub** on cache hits (name/node_type/version/path/target_service, `children: None`).

This is behavior-identical: `flatten_topology::collect` dedups by visited path and early-returns on repeat encounters, so the embedded subtree copies never contributed anything to the output — only the first in-tree occurrence's subtree is ever traversed.

## Validation (on the affected monorepo, staging @ a18cbd7d)

| | before | after |
|---|---|---|
| CLI process RSS | **8.3GB+** (12.1GB footprint) | **~20MB** (0.14GB total incl. children) |
| `release create` wall time | 190s+ | **6s** |
| Detection output (env vars / resources / integrations / mesh / scoping) | 84 / 2 / 8 / 3 / 26-52-6 | identical |
| `library_scanner` tests | — | 8/8 pass |

Profiled with zero network: dummy local platform + `FORKLAUNCH_PLATFORM_MANAGEMENT_API_URL` + `--dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved memory efficiency when scanning projects with complex or overlapping import relationships.
  - Reduced redundant processing of previously scanned files, helping scans remain more stable and responsive as project size and complexity increase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->