### PR TITLE
fix(cli): match observe response schemas to the observability API

### DIFF
--- a/cli/src/observe/issues.rs
+++ b/cli/src/observe/issues.rs
@@ -126,7 +126,7 @@ fn list_issues(matches: &ArgMatches) -> Result<()> {
     let status = matches.get_one::<String>("status").cloned();
     let json_output = matches.get_flag("json");
 
-    let response = fetch_issues(
+    let issues = fetch_issues(
         &application_id,
         &environment,
         severity.as_deref(),
@@ -134,9 +134,9 @@ fn list_issues(matches: &ArgMatches) -> Result<()> {
     )?;
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&response)?);
+        println!("{}", serde_json::to_string_pretty(&issues)?);
     } else {
-        print_issues(&response.issues)?;
+        print_issues(&issues)?;
     }
 
     Ok(())
@@ -147,7 +147,7 @@ fn fetch_issues(
     environment: &str,
     severity: Option<&str>,
     status: Option<&str>,
-) -> Result<IssuesResponse> {
+) -> Result<Vec<Issue>> {
     let api_url = get_observability_api_url();
     let mut url = format!(
         "{}/issues?appId={}&env={}",
@@ -387,13 +387,13 @@ struct Issue {
     resolved_by: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct IssuesResponse {
-    issues: Vec<Issue>,
-    #[serde(default)]
-    total: Option<u64>,
-}
+// NOTE: there is deliberately no `IssuesResponse` wrapper type. The list
+// endpoint (`listIssues`) declares `200: schemaValidator.array(IssueSchema)`
+// and responds with a bare JSON array. The previous wrapper struct
+// (`{issues, total}`) never matched, so every call failed with
+// `invalid length 0, expected struct IssuesResponse with 2 elements`.
+// If pagination/total is added server-side, reintroduce a wrapper here and
+// update `fetch_issues` at the same time.
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -549,19 +549,26 @@ mod tests {
         assert!(issue.service_name.is_none());
     }
 
+    /// The list endpoint responds with a bare JSON array, not an object.
+    /// Shape mirrors `listIssues` (`200: schemaValidator.array(IssueSchema)`).
     #[test]
-    fn issues_response_deserializes() {
-        let json = r#"{
-            "issues": [
-                {"id": "iss-001", "severity": "ALERT"},
-                {"id": "iss-002", "severity": "INCIDENT"}
-            ],
-            "total": 2
-        }"#;
+    fn issues_list_deserializes_bare_array() {
+        let json = r#"[
+            {"id": "iss-001", "severity": "ALERT"},
+            {"id": "iss-002", "severity": "INCIDENT"}
+        ]"#;
 
-        let response: IssuesResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.issues.len(), 2);
-        assert_eq!(response.total, Some(2));
+        let issues: Vec<Issue> = serde_json::from_str(json).unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].id, "iss-001");
+    }
+
+    /// Regression: an empty catalog returns `[]`. The old wrapper struct made
+    /// this fail with `invalid length 0, expected struct ... with 2 elements`.
+    #[test]
+    fn issues_list_deserializes_empty_array() {
+        let issues: Vec<Issue> = serde_json::from_str("[]").unwrap();
+        assert!(issues.is_empty());
     }
 
     #[test]

--- a/cli/src/observe/metrics.rs
+++ b/cli/src/observe/metrics.rs
@@ -345,6 +345,11 @@ impl<'de> Deserialize<'de> for MetricValue {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum Raw {
+            // An explicitly null metric renders as "-" rather than failing the
+            // whole command. The schema types these as required numbers, but
+            // trusting that assumption is what caused this bug in the first
+            // place.
+            Null,
             Scalar(f64),
             Object {
                 #[serde(default)]
@@ -357,6 +362,7 @@ impl<'de> Deserialize<'de> for MetricValue {
         }
 
         Ok(match Raw::deserialize(deserializer)? {
+            Raw::Null => MetricValue::default(),
             Raw::Scalar(value) => MetricValue {
                 value: Some(value),
                 unit: None,
@@ -550,4 +556,26 @@ mod tests {
         assert_eq!(default_unit("Latency p95"), Some("ms"));
         assert_eq!(default_unit("Something Else"), None);
     }
+    /// A metric explicitly sent as `null` should render as "-", not abort the
+    /// command. Schema says these are required numbers; this guards the case
+    /// where reality disagrees (which is the whole reason this PR exists).
+    #[test]
+    fn metric_value_accepts_null() {
+        let mv: MetricValue = serde_json::from_str("null").unwrap();
+        assert!(mv.value.is_none());
+
+        let resp: ApplicationMonitoringResponse =
+            serde_json::from_str(r#"{"requestRate": null, "errorRate": 1, "uptime": 2}"#).unwrap();
+        assert!(resp.request_rate.value.is_none());
+        assert_eq!(resp.error_rate.value, Some(1.0));
+    }
+
+    /// A metric key absent entirely falls back to the struct default.
+    #[test]
+    fn application_monitoring_response_tolerates_missing_metrics() {
+        let resp: ApplicationMonitoringResponse = serde_json::from_str("{}").unwrap();
+        assert!(resp.request_rate.value.is_none());
+        assert!(resp.latency.is_none());
+    }
+
 }

--- a/cli/src/observe/metrics.rs
+++ b/cli/src/observe/metrics.rs
@@ -161,12 +161,26 @@ fn fetch_all_application_metrics(
     let mut merged = ApplicationMonitoringResponse::default();
     let mut latency = LatencyMetric::default();
     let mut any_latency = false;
+    let mut succeeded = false;
+    let mut first_err: Option<anyhow::Error> = None;
 
     for chart_type in ["requestRate", "errorRate", "latencyP50", "latencyP95", "latencyP99"] {
         let r = match fetch_application_metrics(application_id, environment, time_range, chart_type)
         {
-            Ok(r) => r,
-            Err(_) => continue,
+            Ok(r) => {
+                succeeded = true;
+                r
+            }
+            Err(e) => {
+                // Degrade one metric to "-" rather than losing the command —
+                // but never swallow a total failure (auth rejected, API down),
+                // which must still surface as an error instead of a table of
+                // dashes and a zero exit code.
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+                continue;
+            }
         };
         match chart_type {
             "requestRate" => merged.request_rate = r.request_rate,
@@ -189,6 +203,12 @@ fn fetch_all_application_metrics(
                 any_latency |= latency.p99.is_some();
             }
             _ => {}
+        }
+    }
+
+    if !succeeded {
+        if let Some(e) = first_err {
+            return Err(e);
         }
     }
 

--- a/cli/src/observe/metrics.rs
+++ b/cli/src/observe/metrics.rs
@@ -96,7 +96,7 @@ impl CliCommand for MetricsCommand {
                 print_promql(&response)?;
             }
         } else {
-            let response = fetch_application_metrics(&application_id, &environment, &time_range)?;
+            let response = fetch_all_application_metrics(&application_id, &environment, &time_range)?;
             if json_output {
                 println!("{}", serde_json::to_string_pretty(&response)?);
             } else {
@@ -110,18 +110,27 @@ impl CliCommand for MetricsCommand {
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
+/// The endpoint fills in exactly ONE metric per call, chosen by `chartType`
+/// (see `transformToControllerMonitoring`'s `switch (chartType)`); every other
+/// field is returned as a literal `0`, and `uptime` is derived as
+/// `100 - errorRate`. Omitting `chartType` defaults it to `requestRate`, which
+/// is why the command used to print `Latency p50: 0.0000` and
+/// `Uptime: 100.0000` as if they were real measurements. Callers must request
+/// each metric they intend to display — see `fetch_all_application_metrics`.
 fn fetch_application_metrics(
     application_id: &str,
     environment: &str,
     time_range: &str,
+    chart_type: &str,
 ) -> Result<ApplicationMonitoringResponse> {
     let api_url = get_observability_api_url();
     let url = format!(
-        "{}/applications/{}/monitoring?environment={}&timeRange={}",
+        "{}/applications/{}/monitoring?environment={}&timeRange={}&chartType={}",
         api_url,
         urlencoding::encode(application_id),
         urlencoding::encode(environment),
         urlencoding::encode(time_range),
+        urlencoding::encode(chart_type),
     );
 
     let auth_mode = AuthMode::detect();
@@ -139,6 +148,52 @@ fn fetch_application_metrics(
     response
         .json()
         .with_context(|| "Failed to parse metrics response")
+}
+
+/// Fetch each metric the display shows, since the endpoint only populates one
+/// per request. A failure on any single metric is not fatal — that row simply
+/// renders as "-" rather than losing the whole command.
+fn fetch_all_application_metrics(
+    application_id: &str,
+    environment: &str,
+    time_range: &str,
+) -> Result<ApplicationMonitoringResponse> {
+    let mut merged = ApplicationMonitoringResponse::default();
+    let mut latency = LatencyMetric::default();
+    let mut any_latency = false;
+
+    for chart_type in ["requestRate", "errorRate", "latencyP50", "latencyP95", "latencyP99"] {
+        let r = match fetch_application_metrics(application_id, environment, time_range, chart_type)
+        {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        match chart_type {
+            "requestRate" => merged.request_rate = r.request_rate,
+            "errorRate" => {
+                merged.error_rate = r.error_rate;
+                // uptime is derived from errorRate server-side, so it is only
+                // meaningful on the errorRate call.
+                merged.uptime = r.uptime;
+            }
+            "latencyP50" => {
+                latency.p50 = r.latency.and_then(|l| l.p50);
+                any_latency |= latency.p50.is_some();
+            }
+            "latencyP95" => {
+                latency.p95 = r.latency.and_then(|l| l.p95);
+                any_latency |= latency.p95.is_some();
+            }
+            "latencyP99" => {
+                latency.p99 = r.latency.and_then(|l| l.p99);
+                any_latency |= latency.p99.is_some();
+            }
+            _ => {}
+        }
+    }
+
+    merged.latency = if any_latency { Some(latency) } else { None };
+    Ok(merged)
 }
 
 fn fetch_promql(
@@ -240,19 +295,6 @@ fn print_metrics(response: &ApplicationMonitoringResponse) -> Result<()> {
     Ok(())
 }
 
-/// Fallback unit for a metric the API sent as a bare number. The API's own
-/// unit map (monitoring controller) is the source of these strings; without
-/// them every row would render its unit column as "-".
-fn default_unit(name: &str) -> Option<&'static str> {
-    match name {
-        "Request Rate" => Some("req/s"),
-        "Error Rate" => Some("%"),
-        "Uptime" => Some("%"),
-        n if n.starts_with("Latency") => Some("ms"),
-        _ => None,
-    }
-}
-
 fn print_metric_row(out: &mut StandardStream, name: &str, metric: &MetricValue) -> Result<()> {
     let available = metric.available.unwrap_or(true);
     let value_str = if available {
@@ -263,11 +305,12 @@ fn print_metric_row(out: &mut StandardStream, name: &str, metric: &MetricValue) 
     } else {
         "unavailable".to_string()
     };
-    let unit_str = metric
-        .unit
-        .as_deref()
-        .or_else(|| default_unit(name))
-        .unwrap_or("-");
+    // No client-side unit defaults: ApplicationMonitoringSchema carries no unit
+    // for these values, and guessing is worse than showing nothing. The server's
+    // own numbers are req/MINUTE (monitoring-transforms.ts multiplies rate by 60)
+    // and latency comes from `http_server_duration_seconds_bucket` (seconds), so
+    // any hardcoded "req/s"/"ms" here would be actively wrong.
+    let unit_str = metric.unit.as_deref().unwrap_or("-");
 
     if !available {
         out.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
@@ -309,9 +352,17 @@ fn print_promql(response: &PromQLResponse) -> Result<()> {
                 writeln!(stdout, "  {{<no labels>}}")?;
             }
 
-            // Value tuple: [timestamp_f64, value_string]
-            if series.value.len() == 2 {
-                writeln!(stdout, "       value: {}", series.value[1])?;
+            // Each sample is a [timestamp, value] pair; show the latest.
+            match series.values.last() {
+                Some(sample) if sample.len() == 2 => {
+                    writeln!(stdout, "       value: {}", sample[1])?;
+                    if series.values.len() > 1 {
+                        writeln!(stdout, "       ({} samples)", series.values.len())?;
+                    }
+                }
+                _ => {
+                    writeln!(stdout, "       (no samples)")?;
+                }
             }
         }
     }
@@ -381,7 +432,7 @@ impl<'de> Deserialize<'de> for MetricValue {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LatencyMetric {
     #[serde(default)]
@@ -396,7 +447,7 @@ struct LatencyMetric {
     available: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ApplicationMonitoringResponse {
     #[serde(default)]
@@ -424,8 +475,15 @@ impl Default for MetricValue {
 struct PromQLResultEntry {
     #[serde(default)]
     metric: HashMap<String, String>,
+    /// The controller normalizes to the PLURAL key and always nests:
+    /// `values: r.values ?? (r.value ? [r.value] : [])`
+    /// (monitoring.controller.ts), typed `values: array(array(unknown))`.
+    /// Reading the singular `value` here meant this silently deserialized to an
+    /// empty Vec — no error, just every series printed with no data.
+    /// Queries always go through query_range, so resultType is `matrix` and
+    /// each element is a `[timestamp, value]` pair.
     #[serde(default)]
-    value: Vec<serde_json::Value>,
+    values: Vec<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -477,26 +535,33 @@ mod tests {
 
     #[test]
     fn promql_response_deserializes() {
+        // Real shape: queries always go through query_range, so resultType is
+        // `matrix` and samples arrive under the PLURAL `values` key as
+        // [timestamp, value] pairs (monitoring.controller.ts normalizes this).
         let json = r#"{
             "status": "success",
             "data": {
-                "resultType": "vector",
+                "resultType": "matrix",
                 "result": [
                     {
                         "metric": {"__name__": "http_requests_total", "job": "api"},
-                        "value": [1700000000.0, "42"]
+                        "values": [[1700000000.0, "41"], [1700000060.0, "42"]]
                     }
                 ]
             }
         }"#;
         let resp: PromQLResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.status, "success");
-        assert_eq!(resp.data.result_type, "vector");
+        assert_eq!(resp.data.result_type, "matrix");
         assert_eq!(resp.data.result.len(), 1);
         assert_eq!(
             resp.data.result[0].metric.get("job").map(|s| s.as_str()),
             Some("api")
         );
+        // latest sample is what print_promql shows
+        let last = resp.data.result[0].values.last().unwrap();
+        assert_eq!(last[1], serde_json::json!("42"));
+        assert_eq!(resp.data.result[0].values.len(), 2);
     }
 
     #[test]
@@ -550,12 +615,6 @@ mod tests {
         assert!(mv.unit.is_none());
     }
 
-    #[test]
-    fn default_unit_fills_in_when_api_omits_it() {
-        assert_eq!(default_unit("Request Rate"), Some("req/s"));
-        assert_eq!(default_unit("Latency p95"), Some("ms"));
-        assert_eq!(default_unit("Something Else"), None);
-    }
     /// A metric explicitly sent as `null` should render as "-", not abort the
     /// command. Schema says these are required numbers; this guards the case
     /// where reality disagrees (which is the whole reason this PR exists).

--- a/cli/src/observe/metrics.rs
+++ b/cli/src/observe/metrics.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::{
-    CliCommand,
     constants::get_observability_api_url,
     core::{
         command::command,
@@ -14,6 +13,7 @@ use crate::{
         http_client::{get_with_auth, post_with_auth},
         validate::{require_integration, require_manifest},
     },
+    CliCommand,
 };
 
 // ── Top-level command ─────────────────────────────────────────────────────────
@@ -89,16 +89,14 @@ impl CliCommand for MetricsCommand {
         };
 
         if let Some(q) = query {
-            let response =
-                fetch_promql(&q, &environment, &application_id, &time_range)?;
+            let response = fetch_promql(&q, &environment, &application_id, &time_range)?;
             if json_output {
                 println!("{}", serde_json::to_string_pretty(&response)?);
             } else {
                 print_promql(&response)?;
             }
         } else {
-            let response =
-                fetch_application_metrics(&application_id, &environment, &time_range)?;
+            let response = fetch_application_metrics(&application_id, &environment, &time_range)?;
             if json_output {
                 println!("{}", serde_json::to_string_pretty(&response)?);
             } else {
@@ -160,8 +158,8 @@ fn fetch_promql(
     });
 
     let auth_mode = AuthMode::detect();
-    let response =
-        post_with_auth(&auth_mode, &url, body).with_context(|| "Failed to reach observability API")?;
+    let response = post_with_auth(&auth_mode, &url, body)
+        .with_context(|| "Failed to reach observability API")?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -242,6 +240,19 @@ fn print_metrics(response: &ApplicationMonitoringResponse) -> Result<()> {
     Ok(())
 }
 
+/// Fallback unit for a metric the API sent as a bare number. The API's own
+/// unit map (monitoring controller) is the source of these strings; without
+/// them every row would render its unit column as "-".
+fn default_unit(name: &str) -> Option<&'static str> {
+    match name {
+        "Request Rate" => Some("req/s"),
+        "Error Rate" => Some("%"),
+        "Uptime" => Some("%"),
+        n if n.starts_with("Latency") => Some("ms"),
+        _ => None,
+    }
+}
+
 fn print_metric_row(out: &mut StandardStream, name: &str, metric: &MetricValue) -> Result<()> {
     let available = metric.available.unwrap_or(true);
     let value_str = if available {
@@ -252,7 +263,11 @@ fn print_metric_row(out: &mut StandardStream, name: &str, metric: &MetricValue) 
     } else {
         "unavailable".to_string()
     };
-    let unit_str = metric.unit.as_deref().unwrap_or("-");
+    let unit_str = metric
+        .unit
+        .as_deref()
+        .or_else(|| default_unit(name))
+        .unwrap_or("-");
 
     if !available {
         out.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
@@ -308,15 +323,56 @@ fn print_promql(response: &PromQLResponse) -> Result<()> {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MetricValue {
-    #[serde(default)]
     value: Option<f64>,
-    #[serde(default)]
     unit: Option<String>,
-    #[serde(default)]
     available: Option<bool>,
+}
+
+/// The observability API sends these metrics as bare JSON numbers —
+/// `"requestRate": 12.5` (see `ApplicationMonitoringSchema`, which types
+/// `requestRate`/`errorRate`/`uptime` as `number`). Earlier CLI versions
+/// assumed an object (`{value, unit, available}`), which made every
+/// `observe metrics` call fail with `invalid type: integer, expected struct
+/// MetricValue`. Accept both shapes so the CLI survives either side changing.
+impl<'de> Deserialize<'de> for MetricValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Scalar(f64),
+            Object {
+                #[serde(default)]
+                value: Option<f64>,
+                #[serde(default)]
+                unit: Option<String>,
+                #[serde(default)]
+                available: Option<bool>,
+            },
+        }
+
+        Ok(match Raw::deserialize(deserializer)? {
+            Raw::Scalar(value) => MetricValue {
+                value: Some(value),
+                unit: None,
+                available: None,
+            },
+            Raw::Object {
+                value,
+                unit,
+                available,
+            } => MetricValue {
+                value,
+                unit,
+                available,
+            },
+        })
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -455,5 +511,43 @@ mod tests {
         let resp: ApplicationMonitoringResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.request_rate.value, Some(10.0));
         assert!(resp.latency.is_some());
+    }
+
+    /// Regression — the shape the API ACTUALLY returns
+    /// (`ApplicationMonitoringSchema`: `requestRate`/`errorRate`/`uptime` are
+    /// plain `number`, latency is `{p50,p95,p99,avg}`). This previously failed
+    /// with `invalid type: integer 0, expected struct MetricValue`.
+    #[test]
+    fn application_monitoring_response_deserializes_scalar_metrics() {
+        let json = r#"{
+            "requestRate": 0,
+            "requestRateTrend": "—",
+            "latency": {"p50": 10.0, "p95": 50.0, "p99": 100.0, "avg": 22.0},
+            "latencyTrend": "—",
+            "errorRate": 0.5,
+            "errorRateTrend": "+1.2%",
+            "successRatePercent": 99.5,
+            "available": true,
+            "uptime": 99.9
+        }"#;
+        let resp: ApplicationMonitoringResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.request_rate.value, Some(0.0));
+        assert_eq!(resp.error_rate.value, Some(0.5));
+        assert_eq!(resp.uptime.value, Some(99.9));
+        assert_eq!(resp.latency.as_ref().and_then(|l| l.p95), Some(50.0));
+    }
+
+    #[test]
+    fn metric_value_accepts_bare_number() {
+        let mv: MetricValue = serde_json::from_str("0").unwrap();
+        assert_eq!(mv.value, Some(0.0));
+        assert!(mv.unit.is_none());
+    }
+
+    #[test]
+    fn default_unit_fills_in_when_api_omits_it() {
+        assert_eq!(default_unit("Request Rate"), Some("req/s"));
+        assert_eq!(default_unit("Latency p95"), Some("ms"));
+        assert_eq!(default_unit("Something Else"), None);
     }
 }

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -192,6 +192,18 @@ fn fetch_trace_detail(
 
 // ── Display ───────────────────────────────────────────────────────────────────
 
+/// Shown where the API omitted an optional field (route, service, status).
+const MISSING: &str = "—";
+
+/// Truncate to `max` display characters, appending an ellipsis when clipped.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        format!("{}…", s.chars().take(max - 1).collect::<String>())
+    } else {
+        s.to_string()
+    }
+}
+
 fn print_traces(traces: &[TraceEntry]) -> Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
 
@@ -223,19 +235,11 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
 
     for trace in traces {
         let trace_id_short = trace.trace_id.get(..12).unwrap_or(&trace.trace_id);
-        let service = if trace.service_name.chars().count() > 20 {
-            format!(
-                "{}…",
-                trace.service_name.chars().take(19).collect::<String>()
-            )
-        } else {
-            trace.service_name.clone()
-        };
-        let route = if trace.route.chars().count() > 30 {
-            format!("{}…", trace.route.chars().take(29).collect::<String>())
-        } else {
-            trace.route.clone()
-        };
+        // service/route/status are optional server-side — show a placeholder
+        // instead of failing or leaving the column blank.
+        let service = truncate(trace.service_name.as_deref().unwrap_or(MISSING), 20);
+        let route = truncate(trace.route.as_deref().unwrap_or(MISSING), 30);
+        let status = trace.status.as_deref().unwrap_or(MISSING);
         let duration = format!("{}ms", trace.duration_ms);
         let start_time = trace
             .start_time
@@ -243,7 +247,7 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
             .map(|s| s.replace('T', " "))
             .unwrap_or_else(|| trace.start_time.clone());
 
-        let color = status_color(&trace.status);
+        let color = status_color(status);
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
         write!(
             stdout,
@@ -251,7 +255,7 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
             trace_id_short, service, route, duration
         )?;
         stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
-        write!(stdout, "{:<10}", trace.status)?;
+        write!(stdout, "{:<10}", status)?;
         stdout.reset()?;
         writeln!(stdout, "  {}", start_time)?;
     }
@@ -306,7 +310,12 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         stdout.reset()?;
 
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
-        writeln!(stdout, "  ({}, {}ms)", span.service_name, span.duration_ms)?;
+        writeln!(
+            stdout,
+            "  ({}, {}ms)",
+            span.service_name.as_deref().unwrap_or(MISSING),
+            span.duration_ms
+        )?;
         stdout.reset()?;
     }
 
@@ -377,14 +386,22 @@ fn status_color(status: &str) -> Color {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/// Mirrors the API's trace summary. `serviceName`, `route` and `status` are
+/// declared `.optional()` server-side (see `ServiceTracesResponseSchema`) —
+/// not every span is an HTTP request, so a trace can legitimately arrive
+/// without a route. Treating them as required made the whole command fail with
+/// `missing field \`route\`` the moment one such trace appeared.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TraceEntry {
     trace_id: String,
-    service_name: String,
-    route: String,
+    #[serde(default)]
+    service_name: Option<String>,
+    #[serde(default)]
+    route: Option<String>,
     duration_ms: u64,
-    status: String,
+    #[serde(default)]
+    status: Option<String>,
     start_time: String,
 }
 
@@ -403,7 +420,10 @@ struct Span {
     #[serde(default)]
     parent_span_id: Option<String>,
     name: String,
-    service_name: String,
+    /// `.optional()` server-side, same as on `TraceEntry` — required here would
+    /// break `observe traces <id>` on any span without a service name.
+    #[serde(default)]
+    service_name: Option<String>,
     start_time: String,
     duration_ms: u64,
     #[serde(default)]
@@ -438,7 +458,7 @@ mod tests {
             span_id: span_id.to_string(),
             parent_span_id: parent_span_id.map(|s| s.to_string()),
             name: name.to_string(),
-            service_name: "svc".to_string(),
+            service_name: Some("svc".to_string()),
             start_time: "2024-01-15T10:00:00Z".to_string(),
             duration_ms: 100,
             attributes: HashMap::new(),
@@ -552,6 +572,24 @@ mod tests {
         let entry: TraceEntry = serde_json::from_str(json).unwrap();
         assert_eq!(entry.trace_id, "abc123");
         assert_eq!(entry.duration_ms, 42);
+        assert_eq!(entry.route.as_deref(), Some("/health"));
+    }
+
+    /// Regression: `route`, `serviceName` and `status` are `.optional()`
+    /// server-side. A non-HTTP trace arrives without them and previously blew
+    /// the whole command up with `missing field \`route\``.
+    #[test]
+    fn trace_entry_deserializes_without_optional_fields() {
+        let json = r#"{
+            "traceId": "abc123",
+            "durationMs": 42,
+            "startTime": "2024-01-15T10:00:00Z"
+        }"#;
+        let entry: TraceEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.trace_id, "abc123");
+        assert!(entry.route.is_none());
+        assert!(entry.service_name.is_none());
+        assert!(entry.status.is_none());
     }
 
     #[test]

--- a/cli/src/observe/traces.rs
+++ b/cli/src/observe/traces.rs
@@ -240,7 +240,7 @@ fn print_traces(traces: &[TraceEntry]) -> Result<()> {
         let service = truncate(trace.service_name.as_deref().unwrap_or(MISSING), 20);
         let route = truncate(trace.route.as_deref().unwrap_or(MISSING), 30);
         let status = trace.status.as_deref().unwrap_or(MISSING);
-        let duration = format!("{}ms", trace.duration_ms);
+        let duration = format!("{:.0}ms", trace.duration_ms);
         let start_time = trace
             .start_time
             .get(..19)
@@ -299,7 +299,7 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
             .unwrap_or(false);
         let color = if is_error {
             Color::Red
-        } else if span.duration_ms > 1000 {
+        } else if span.duration_ms > 1000.0 {
             Color::Yellow
         } else {
             Color::Green
@@ -312,7 +312,7 @@ fn print_trace_detail(response: &TraceDetailResponse) -> Result<()> {
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
         writeln!(
             stdout,
-            "  ({}, {}ms)",
+            "  ({}, {:.2}ms)",
             span.service_name.as_deref().unwrap_or(MISSING),
             span.duration_ms
         )?;
@@ -399,7 +399,10 @@ struct TraceEntry {
     service_name: Option<String>,
     #[serde(default)]
     route: Option<String>,
-    duration_ms: u64,
+    /// Fractional: the server computes this as (endNano-startNano)/1e6 with no
+    /// rounding, so it is not an integer in general. `u64` rejected every float
+    /// value serde saw — including whole ones like `12.0`.
+    duration_ms: f64,
     #[serde(default)]
     status: Option<String>,
     start_time: String,
@@ -425,7 +428,10 @@ struct Span {
     #[serde(default)]
     service_name: Option<String>,
     start_time: String,
-    duration_ms: u64,
+    /// Fractional: the server computes this as (endNano-startNano)/1e6 with no
+    /// rounding, so it is not an integer in general. `u64` rejected every float
+    /// value serde saw — including whole ones like `12.0`.
+    duration_ms: f64,
     #[serde(default)]
     attributes: HashMap<String, serde_json::Value>,
 }
@@ -460,7 +466,7 @@ mod tests {
             name: name.to_string(),
             service_name: Some("svc".to_string()),
             start_time: "2024-01-15T10:00:00Z".to_string(),
-            duration_ms: 100,
+            duration_ms: 100.0,
             attributes: HashMap::new(),
         }
     }
@@ -571,8 +577,28 @@ mod tests {
         }"#;
         let entry: TraceEntry = serde_json::from_str(json).unwrap();
         assert_eq!(entry.trace_id, "abc123");
-        assert_eq!(entry.duration_ms, 42);
+        assert_eq!(entry.duration_ms, 42.0);
         assert_eq!(entry.route.as_deref(), Some("/health"));
+    }
+
+    /// Regression: the server computes durations as
+    /// `(endNano - startNano) / 1_000_000` with no rounding
+    /// (traces.service.ts durationFromNano), so `durationMs` is fractional in
+    /// general. `u64` rejected every float — including whole ones like `12.0`
+    /// — which broke `observe traces <trace-id>` entirely.
+    #[test]
+    fn fractional_durations_deserialize() {
+        let span: Span = serde_json::from_str(
+            r#"{"spanId":"s1","name":"http.request","startTime":"2024-01-15T10:00:00Z","durationMs":55.45556640625}"#,
+        )
+        .unwrap();
+        assert!((span.duration_ms - 55.45556640625).abs() < f64::EPSILON);
+
+        let entry: TraceEntry = serde_json::from_str(
+            r#"{"traceId":"t1","startTime":"2024-01-15T10:00:00Z","durationMs":12.0}"#,
+        )
+        .unwrap();
+        assert!((entry.duration_ms - 12.0).abs() < f64::EPSILON);
     }
 
     /// Regression: `route`, `serviceName` and `status` are `.optional()`


### PR DESCRIPTION
Reported by @Hemant-Parihar — `observe issues`, `observe metrics` and `observe traces` all failed at deserialization. `observe status` and `observe logs` were unaffected.

Root cause: the CLI's hand-written Rust response types had drifted from what the observability API actually returns. Auditing the same files against the platform source turned up four further defects, including one that meant a reported command was **still** broken after the initial fix.

## The three reported failures

| Command | API returns | CLI expected | Error |
|---|---|---|---|
| `issues` | bare array — `200: array(IssueSchema)` (`issue.controller.ts:60`) | `{issues, total}` wrapper | `invalid length 0, expected struct IssuesResponse with 2 elements` |
| `metrics` | `requestRate`/`errorRate`/`uptime` as plain `number` (`monitoring.schema.ts:29-38`) | `{value, unit, available}` object | `invalid type: integer 0, expected struct MetricValue` |
| `traces` | `serviceName`/`route`/`status` are `.optional()` (`traces.schema.ts:28,32,33`) | required `String` | `missing field 'route'` |

## Four further defects found while verifying

1. **`observe traces <trace-id>` was still broken.** `durationFromNano` (`traces.service.ts:876`) computes `(endNano - startNano) / 1e6` with no rounding, so durations are fractional. `duration_ms: u64` rejects *every* float — including whole values like `12.0`. Now `f64`, rounded at render.

2. **`observe metrics` printed fabricated numbers.** `transformToControllerMonitoring` populates exactly one metric per request via `switch (chartType)`, leaving the rest as literal `0` and deriving `uptime = 100 - errorRate`. The CLI never sent `chartType`, so it displayed `Latency p50: 0.0000` and `Uptime: 100.0000` as though measured. It now requests each metric it displays and merges.

3. **`observe metrics --query` failed silently.** The CLI read `value`; the controller normalizes to the plural `values`, always nested (`array(array(unknown))`, `monitoring.controller.ts:441`). With `#[serde(default)]` this deserialized to an empty vec — series printed with no data and no error.

4. **A total fetch failure produced empty output.** The per-metric fan-out degraded each failed metric to `-`, which also swallowed auth rejection / API-down. Partial failure still degrades one row; total failure now propagates.

## Also corrected mid-PR

An earlier commit added client-side unit labels (`req/s`, `ms`). Both are wrong: `monitoring-transforms.ts:101` does `requestRate = displayValue * 60` (per **minute**), and latency comes from `http_server_duration_seconds_bucket` (**seconds**). Removed — a `-` that claims nothing beats a confident 60× mislabel.

## Why CI was green

The unit tests deserialized hand-written fixtures encoding the *assumed* shapes — e.g. `{"issues": [...], "total": 2}`, a payload the API never sends. They validated the assumption, not the contract.

Fixtures now mirror the real schemas, with regressions for: empty array, scalar metrics, null metrics, missing optional trace fields, fractional durations, and the PromQL matrix shape.

## Verification

- Routing traced end-to-end (there are two `/:id/traces` controllers and seven monitoring routers — confirmed the CLI hits `applicationTracesRouter`, so `ServiceTracesResponseSchema` is the correct schema).
- `ListIssuesQuerySchema` accepts exactly the `appId`/`env`/`severity`/`status` the CLI sends.
- `cargo test` 334 passed / 0 failed; clippy clean on changed files.
- **Not yet run against the live API** — verification is schema-level plus unit tests. @Hemant-Parihar has the environment that reproduced this and has offered to re-confirm post-merge.

## Note on scope

Fix targets the CLI, not the API, since the API shapes are already shipped and consumed by the frontend. Item 2 above is a behavioral change (one request becomes five, server-cached per `chartType`) — flagging explicitly for review, since it goes beyond pure schema matching. Happy to split it out if preferred.

## Follow-up

These Rust types are hand-maintained against schemas in a different repo with nothing linking them — which is how five defects accumulated across three endpoints. Generating them from the platform schemas is the durable fix; worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)