### PR TITLE
fix(cli): scaffold installs clean — seed/preserve allowBuilds, heal pnpm placeholders

### DIFF
--- a/cli/src/change/application.rs
+++ b/cli/src/change/application.rs
@@ -1174,9 +1174,10 @@ fn change_runtime(
                 "pnpm-workspace.yaml".to_string(),
                 RenderedTemplate {
                     path: base_path.join("pnpm-workspace.yaml"),
-                    content: serde_yml::to_string(&PnpmWorkspace {
-                        packages: existing_workspaces,
-                    })?,
+                    content: crate::core::pnpm_workspace::render_pnpm_workspace_with_packages(
+                        base_path,
+                        existing_workspaces,
+                    )?,
                     context: None,
                 },
             );

--- a/cli/src/core/pnpm_workspace.rs
+++ b/cli/src/core/pnpm_workspace.rs
@@ -1,8 +1,8 @@
-use std::{fs::read_to_string, path::Path};
+use std::{collections::BTreeMap, fs::read_to_string, path::Path};
 
 use anyhow::{Context, Ok, Result};
 use serde::{Deserialize, Serialize};
-use serde_yml::{from_str, to_string};
+use serde_yml::{Value, from_str, to_string};
 
 use super::{manifest::InitializableManifestConfig, rendered_template::RenderedTemplate};
 use crate::{
@@ -14,9 +14,68 @@ use crate::{
     core::manifest::{ManifestConfig, ProjectEntry, ProjectManifestConfig},
 };
 
+/// Dependencies the scaffold ships (directly or transitively) that run
+/// install-time build scripts. pnpm 10+ blocks build scripts unless they are
+/// listed under `allowBuilds`; when the list is missing, pnpm writes literal
+/// "set this to true or false" placeholders into pnpm-workspace.yaml, which
+/// then fail every subsequent install. Pre-seed real values so pnpm never
+/// injects placeholders.
+const ALLOWED_BUILD_DEPENDENCIES: &[&str] = &[
+    "@scarf/scarf",
+    "better-sqlite3",
+    "cpu-features",
+    "esbuild",
+    "msgpackr-extract",
+    "protobufjs",
+    "sqlite3",
+    "ssh2",
+    "tldjs",
+    "unrs-resolver",
+];
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub(crate) struct PnpmWorkspace {
     pub(crate) packages: Vec<String>,
+    #[serde(
+        rename = "allowBuilds",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) allow_builds: Option<BTreeMap<String, Value>>,
+    // Preserve any keys this struct does not model (overrides, catalogs,
+    // blockExoticSubdeps, ...) so re-emitting the file never clobbers
+    // consumer or tool-added configuration.
+    #[serde(flatten)]
+    pub(crate) other: BTreeMap<String, Value>,
+}
+
+fn default_allow_builds() -> BTreeMap<String, Value> {
+    ALLOWED_BUILD_DEPENDENCIES
+        .iter()
+        .map(|dep| ((*dep).to_string(), Value::Bool(true)))
+        .collect()
+}
+
+/// pnpm writes string placeholders ("set this to true or false") for
+/// unapproved build deps. Coerce any non-boolean entries to `true` and make
+/// sure the scaffold's known build deps are present, healing workspaces that
+/// picked up placeholders before this fix.
+fn sanitize_allow_builds(pnpm_workspace: &mut PnpmWorkspace) {
+    let mut allow_builds = pnpm_workspace
+        .allow_builds
+        .take()
+        .unwrap_or_else(default_allow_builds);
+    for value in allow_builds.values_mut() {
+        if !matches!(value, Value::Bool(_)) {
+            *value = Value::Bool(true);
+        }
+    }
+    for dep in ALLOWED_BUILD_DEPENDENCIES {
+        allow_builds
+            .entry((*dep).to_string())
+            .or_insert(Value::Bool(true));
+    }
+    pnpm_workspace.allow_builds = Some(allow_builds);
 }
 
 pub(crate) fn generate_pnpm_workspace(
@@ -32,10 +91,39 @@ pub(crate) fn generate_pnpm_workspace(
         path: pnpm_workspace_path,
         content: to_string(&PnpmWorkspace {
             packages: additional_projects.iter().map(|p| p.name.clone()).collect(),
+            allow_builds: Some(default_allow_builds()),
+            other: BTreeMap::new(),
         })
         .with_context(|| ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE)?,
         context: None,
     }))
+}
+
+/// Render a pnpm-workspace.yaml with the given package list, preserving any
+/// existing configuration (allowBuilds, overrides, ...) from the file at
+/// `base_path` when present.
+pub(crate) fn render_pnpm_workspace_with_packages(
+    base_path: &Path,
+    packages: Vec<String>,
+) -> Result<String> {
+    let pnpm_workspace_path = base_path.join("pnpm-workspace.yaml");
+    let mut pnpm_workspace: PnpmWorkspace = if pnpm_workspace_path.exists() {
+        from_str(
+            &read_to_string(&pnpm_workspace_path)
+                .with_context(|| ERROR_FAILED_TO_READ_PNPM_WORKSPACE)?,
+        )
+        .with_context(|| ERROR_FAILED_TO_PARSE_PNPM_WORKSPACE)?
+    } else {
+        PnpmWorkspace {
+            packages: Vec::new(),
+            allow_builds: None,
+            other: BTreeMap::new(),
+        }
+    };
+    pnpm_workspace.packages = packages;
+    sanitize_allow_builds(&mut pnpm_workspace);
+    Ok(to_string(&pnpm_workspace)
+        .with_context(|| ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE)?)
 }
 
 pub(crate) fn add_project_definition_to_pnpm_workspace<
@@ -53,6 +141,7 @@ pub(crate) fn add_project_definition_to_pnpm_workspace<
     if !pnpm_workspace.packages.contains(&manifest_data.name()) {
         pnpm_workspace.packages.push(manifest_data.name().clone());
     }
+    sanitize_allow_builds(&mut pnpm_workspace);
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_PNPM_WORKSPACE)?)
 }
@@ -74,7 +163,8 @@ pub(crate) fn remove_project_definition_to_pnpm_workspace(
     {
         pnpm_workspace.packages.remove(position);
     }
-    
+    sanitize_allow_builds(&mut pnpm_workspace);
+
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_PNPM_WORKSPACE)?)
 }

--- a/cli/src/release/create.rs
+++ b/cli/src/release/create.rs
@@ -463,9 +463,20 @@ impl CliCommand for CreateCommand {
                 vec!["install"]
             };
 
-            let install_status = ProcessCommand::new(&resolved)
+            let mut install_command = ProcessCommand::new(&resolved);
+            install_command
                 .args(&install_args)
-                .current_dir(&modules_path)
+                .current_dir(&modules_path);
+            // Bun's installer can be blocked by its temporary-directory
+            // sandbox in restricted environments; point it at a project-local
+            // temp dir that is always writable.
+            if manifest.runtime == "bun" {
+                let bun_tmp = modules_path.join(".forklaunch-tmp");
+                std::fs::create_dir_all(&bun_tmp)
+                    .with_context(|| "Failed to create bun temp directory")?;
+                install_command.env("TMPDIR", &bun_tmp);
+            }
+            let install_status = install_command
                 .status()
                 .with_context(|| format!("Failed to run {} install", runtime_cmd))?;
 

--- a/cli/tests/init_worker_workspace_and_typecheck.sh
+++ b/cli/tests/init_worker_workspace_and_typecheck.sh
@@ -1,0 +1,67 @@
+if [ -d "output/init-worker-workspace" ]; then
+    rm -rf output/init-worker-workspace
+fi
+
+mkdir -p output/init-worker-workspace
+cd output/init-worker-workspace
+
+RUST_BACKTRACE=1 cargo run --release init application workspace-test-app -p workspace-test-app -o src/modules -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -D "Workspace integrity test application" -A "Forklaunch Team" -L 'MIT'
+
+WORKSPACE_YAML="workspace-test-app/src/modules/pnpm-workspace.yaml"
+
+# A fresh scaffold must seed real allowBuilds values, not pnpm placeholders
+if grep -q "set this to true or false" "$WORKSPACE_YAML"; then
+    echo "[ERROR] pnpm-workspace.yaml contains literal placeholder values"
+    exit 1
+fi
+if ! grep -q "esbuild: true" "$WORKSPACE_YAML"; then
+    echo "[ERROR] pnpm-workspace.yaml missing allowBuilds entry for esbuild"
+    exit 1
+fi
+
+RUST_BACKTRACE=1 cargo run --release init worker queue-worker -t bullmq -p workspace-test-app/src/modules -D "BullMQ worker"
+
+# Re-emitting the workspace file must preserve allowBuilds
+if ! grep -q "esbuild: true" "$WORKSPACE_YAML"; then
+    echo "[ERROR] init worker clobbered allowBuilds in pnpm-workspace.yaml"
+    exit 1
+fi
+
+# Simulate a workspace poisoned by pnpm placeholders plus consumer-added
+# config; the next init must heal the placeholders and keep unknown keys
+cat > "$WORKSPACE_YAML" << 'EOF'
+packages:
+- core
+- monitoring
+- client-sdk
+- queue-worker
+allowBuilds:
+  esbuild: set this to true or false
+  protobufjs: set this to true or false
+blockExoticSubdeps: false
+EOF
+
+RUST_BACKTRACE=1 cargo run --release init service checkout -d postgresql -p workspace-test-app/src/modules -D "Checkout service"
+
+if grep -q "set this to true or false" "$WORKSPACE_YAML"; then
+    echo "[ERROR] init service did not heal placeholder allowBuilds values"
+    exit 1
+fi
+if ! grep -q "blockExoticSubdeps: false" "$WORKSPACE_YAML"; then
+    echo "[ERROR] init service clobbered unmodeled workspace configuration"
+    exit 1
+fi
+
+cd workspace-test-app/src/modules
+
+# A fresh scaffold must install and typecheck with zero manual patches
+CI=true pnpm install
+
+for project in core queue-worker checkout; do
+    (cd "$project" && pnpm exec tsgo --noEmit) || {
+        echo "[ERROR] tsc --noEmit failed for $project"
+        exit 1
+    }
+done
+
+pnpm build


### PR DESCRIPTION
## Summary

Fixes the scaffold issues that force downstream consumers (ForkLaunch Studio) to patch generated files after `init`. Audit of the reported five items against main:

| # | Issue | Status |
|---|-------|--------|
| 1 | pnpm-workspace.yaml placeholder breaks installs; re-init clobbers fixes | **Fixed here** |
| 2 | MikroORM version skew (7.0.15 vs 7.1.8) | Already fixed on main (#228): CLI pins 7.1.8, scaffold resolves a single instance |
| 3 | BullMqWorkerOptions.queueOptions TS2345 | Not reproducible on main: scaffold emits concrete `queueOptions`, fresh `init worker -t bullmq` + `tsc --noEmit` passes with 0 errors (was collateral of the #2-era duplicate-package skew) |
| 4 | Root workspace globs `apps/*` | Not present on main: the CLI emits no root pnpm-workspace.yaml and no `apps/*` glob anywhere |
| 5 | Bun temp-dir sandbox blocks module installs | **Mitigated here** |

## Root cause for #1

The placeholder text is written by **pnpm itself**, not the CLI: the post-init `pnpm format` triggers pnpm 11's auto-install, which blocks unapproved build scripts and injects `allowBuilds: { esbuild: set this to true or false, ... }` into the workspace yaml. The CLI then made it unfixable: every `init service/router/worker` and `change application` round-tripped the yaml through a `packages`-only struct, silently dropping `allowBuilds` and any other consumer-added keys.

## Changes

- `generate_pnpm_workspace` seeds `allowBuilds: true` for the scaffold's known build-script deps, so pnpm never injects placeholders
- The workspace struct preserves unmodeled keys (`overrides`, `blockExoticSubdeps`, ...) via serde flatten, and every rewrite heals placeholder string values to `true`
- `change application` renders through the same preserving helper instead of a from-scratch struct
- `release create` bun installs get a project-local `TMPDIR` so Bun's temporary-directory sandbox cannot block them
- New fixture test (`init_worker_workspace_and_typecheck.sh`): scaffolds fresh, asserts no placeholders + `allowBuilds` seeded, asserts survival across `init worker`/`init service`, poisons the yaml with placeholders + foreign keys and asserts healing + preservation, then requires `pnpm install` and per-project `tsc --noEmit` to pass with zero patches

## Test plan

- `cargo test`: 327 passed
- Fixture script run locally end-to-end: passes (install clean, `tsgo --noEmit` clean in core/worker/service, full build green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace configuration now supports build-script allowlists for safer dependency installation.
  - Existing workspace settings, including custom configuration, are preserved when projects are initialized or updated.
  - Missing workspace package entries and pnpm placeholders are automatically restored.

- **Bug Fixes**
  - Runtime switching now keeps workspace package definitions intact.
  - Bun dependency installation uses a project-local temporary directory, improving reliability in restricted environments.
  - Invalid build allowlist values are normalized automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->