### PR TITLE
feat(compliance): audit gating checks, worker tenant wiring, typed session organizationId

### DIFF
--- a/blueprint/sample-worker/worker.ts
+++ b/blueprint/sample-worker/worker.ts
@@ -2,11 +2,18 @@ import {
   WorkerFailureHandler,
   WorkerProcessFunction
 } from '@forklaunch/interfaces-worker/types';
+import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
 import { ci, tokens } from './bootstrapper';
 import { type SampleWorkerEventRecord } from './persistence/entities/sampleWorkerRecord.entity';
 
 const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
 const s3 = ci.resolve(tokens.S3ObjectStore);
+
+//! registers tenant isolation on the worker's ORM so background jobs are
+//! gated the same way as request handling
+const orm = ci.resolve(tokens.Orm);
+setupTenantFilter(orm, { logger: openTelemetryCollector });
+setupRls(orm, { logger: openTelemetryCollector });
 
 const processEvents: (
   name: string

--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -160,11 +160,19 @@ impl CliCommand for AuditCommand {
             );
         }
 
+        // Run offline wiring + sensitive-field checks
+        let local_findings = super::checks::run_local_checks(&modules_path_buf)
+            .unwrap_or_else(|e| {
+                let _ = writeln!(stdout, "[WARN] Failed to run local compliance checks: {}", e);
+                Vec::new()
+            });
+
         // Build the local report
         let report = ComplianceReport {
             generated_at: chrono::Utc::now().to_rfc3339(),
             routes,
             entities,
+            local_findings,
             secrets: SecretsReport {
                 declared: compliance.secrets.clone(),
                 count: compliance.secrets.len(),
@@ -218,6 +226,7 @@ impl CliCommand for AuditCommand {
                     print_findings(&mut stdout, resp)?;
                 }
 
+                print_local_checks(&mut stdout, &report)?;
                 print_entities(&mut stdout, &report)?;
                 print_routes(&mut stdout, &report)?;
 
@@ -238,6 +247,7 @@ impl CliCommand for AuditCommand {
             }
             Err(e) => {
                 // Fallback: local-only display
+                print_local_checks(&mut stdout, &report)?;
                 print_entities(&mut stdout, &report)?;
                 print_routes(&mut stdout, &report)?;
 
@@ -434,6 +444,47 @@ fn print_findings(out: &mut StandardStream, resp: &PlatformAuditResponse) -> Res
         out.reset()?;
 
         writeln!(out, " {}", finding.description)?;
+    }
+
+    Ok(())
+}
+
+fn print_local_checks(out: &mut StandardStream, report: &ComplianceReport) -> Result<()> {
+    writeln!(out)?;
+    out.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_bold(true))?;
+    writeln!(
+        out,
+        "  ── Local checks ({}) ──",
+        report.local_findings.len()
+    )?;
+    out.reset()?;
+
+    if report.local_findings.is_empty() {
+        out.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        writeln!(
+            out,
+            "  ✓ Tenant isolation, retention/erasure wiring, and field classifications look consistent"
+        )?;
+        out.reset()?;
+        return Ok(());
+    }
+
+    for finding in &report.local_findings {
+        let (icon, color, label) = match finding.severity {
+            super::checks::Severity::Warning => ("▲", Color::Yellow, "WARNING"),
+            super::checks::Severity::Info => ("●", Color::Cyan, "REVIEW"),
+        };
+
+        write!(out, "  ")?;
+        out.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(out, "{} [{:>7}]", icon, label)?;
+        out.reset()?;
+
+        out.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
+        write!(out, " [{}] {}:{}", finding.check, finding.project, finding.subject)?;
+        out.reset()?;
+
+        writeln!(out, " — {}", finding.message)?;
     }
 
     Ok(())
@@ -673,6 +724,7 @@ struct ComplianceReport {
     generated_at: String,
     routes: Vec<RouteReport>,
     entities: Vec<EntityReport>,
+    local_findings: Vec<super::checks::LocalFinding>,
     secrets: SecretsReport,
     data_residency: DataResidencyReport,
 }

--- a/cli/src/compliance/checks.rs
+++ b/cli/src/compliance/checks.rs
@@ -1,0 +1,329 @@
+//! Local compliance checks that gate proper setup, run entirely offline.
+//!
+//! Two check families:
+//! 1. Wiring checks — every project that owns persistence entities must
+//!    register the tenant-isolation abstractions (`setupTenantFilter`,
+//!    `setupRls`) in each runtime entrypoint, and register the retention /
+//!    erasure services when its entities declare data that needs them.
+//! 2. Sensitive-field heuristics — fields whose names look like PII / PHI /
+//!    PCI but are classified `none` (or belong to entities that skip
+//!    compliance annotation entirely) are surfaced for review.
+
+use std::{fs, path::Path};
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::core::ast::infrastructure::compliance::scan_entity_compliance;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Severity {
+    Warning,
+    Info,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LocalFinding {
+    pub(crate) severity: Severity,
+    pub(crate) project: String,
+    pub(crate) check: String,
+    pub(crate) subject: String,
+    pub(crate) message: String,
+}
+
+/// Entrypoint files that host a runtime and therefore must wire tenant
+/// isolation when the project owns a database.
+const ENTRYPOINTS: &[&str] = &["server.ts", "worker.ts"];
+
+const TENANT_GATES: &[(&str, &str)] = &[
+    (
+        "setupTenantFilter(",
+        "does not call setupTenantFilter — queries in this runtime are not tenant-filtered",
+    ),
+    (
+        "setupRls(",
+        "does not call setupRls — PostgreSQL row-level security is not enforced in this runtime",
+    ),
+];
+
+/// Field-name words that suggest a classification stronger than `none`.
+/// Matching is done on lowercased words split from camelCase / snake_case,
+/// including joined adjacent pairs (`first_name` -> `firstname`), to keep
+/// false positives down.
+const PII_WORDS: &[&str] = &[
+    "email",
+    "phone",
+    "mobile",
+    "address",
+    "street",
+    "zipcode",
+    "postalcode",
+    "firstname",
+    "lastname",
+    "fullname",
+    "surname",
+    "birth",
+    "birthdate",
+    "birthday",
+    "dob",
+    "gender",
+    "nationality",
+    "passport",
+    "avatar",
+    "photo",
+    "latitude",
+    "longitude",
+    "geolocation",
+    "ipaddress",
+];
+
+const PHI_WORDS: &[&str] = &[
+    "ssn",
+    "medical",
+    "diagnosis",
+    "prescription",
+    "health",
+    "bloodtype",
+    "allergy",
+    "allergies",
+    "disability",
+];
+
+const PCI_WORDS: &[&str] = &[
+    "cardnumber",
+    "creditcard",
+    "pan",
+    "cvv",
+    "cvc",
+    "iban",
+    "accountnumber",
+    "routingnumber",
+    "cardexpiry",
+];
+
+/// Split an identifier into lowercase words plus joined adjacent pairs.
+fn identifier_words(name: &str) -> Vec<String> {
+    let mut words: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for c in name.chars() {
+        if c == '_' || c == '-' {
+            if !current.is_empty() {
+                words.push(current.to_lowercase());
+                current = String::new();
+            }
+        } else if c.is_uppercase() && !current.is_empty() {
+            words.push(current.to_lowercase());
+            current = c.to_string();
+        } else {
+            current.push(c);
+        }
+    }
+    if !current.is_empty() {
+        words.push(current.to_lowercase());
+    }
+    let mut all = words.clone();
+    for pair in words.windows(2) {
+        all.push(format!("{}{}", pair[0], pair[1]));
+    }
+    all
+}
+
+/// Suggest a classification for a field name, if any keyword matches.
+pub(crate) fn suggest_classification(field_name: &str) -> Option<&'static str> {
+    let words = identifier_words(field_name);
+    // Strongest classification wins: PCI, then PHI, then PII.
+    for word in &words {
+        if PCI_WORDS.contains(&word.as_str()) {
+            return Some("pci");
+        }
+    }
+    for word in &words {
+        if PHI_WORDS.contains(&word.as_str()) {
+            return Some("phi");
+        }
+    }
+    for word in &words {
+        if PII_WORDS.contains(&word.as_str()) {
+            return Some("pii");
+        }
+    }
+    None
+}
+
+/// Which tenant gates an entrypoint source is missing.
+pub(crate) fn missing_tenant_gates(source: &str) -> Vec<&'static (&'static str, &'static str)> {
+    TENANT_GATES
+        .iter()
+        .filter(|(call, _)| !source.contains(call))
+        .collect()
+}
+
+/// Run all local checks for every project under `modules_path`.
+pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>> {
+    let mut findings: Vec<LocalFinding> = Vec::new();
+
+    if !modules_path.exists() {
+        return Ok(findings);
+    }
+
+    for entry in fs::read_dir(modules_path)? {
+        let entry = entry?;
+        let project_path = entry.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let project = entry.file_name().to_string_lossy().to_string();
+
+        let owns_persistence = project_path.join("persistence").is_dir();
+
+        // 1. Tenant-isolation wiring in every runtime entrypoint
+        if owns_persistence {
+            for entrypoint in ENTRYPOINTS {
+                let entrypoint_path = project_path.join(entrypoint);
+                if !entrypoint_path.exists() {
+                    continue;
+                }
+                let source = fs::read_to_string(&entrypoint_path)?;
+                for (_, consequence) in missing_tenant_gates(&source) {
+                    findings.push(LocalFinding {
+                        severity: Severity::Warning,
+                        project: project.clone(),
+                        check: "tenant-isolation-wiring".to_string(),
+                        subject: (*entrypoint).to_string(),
+                        message: format!("{} {}", entrypoint, consequence),
+                    });
+                }
+            }
+        }
+
+        // 2. Retention / erasure service registration
+        let entities = scan_entity_compliance(&project_path).unwrap_or_default();
+        if !entities.is_empty() {
+            let has_retention = entities.iter().any(|e| e.retention.is_some());
+            let has_sensitive = entities.iter().any(|e| {
+                e.field_classifications
+                    .values()
+                    .any(|classification| classification != "none")
+            });
+            let registrations = fs::read_to_string(project_path.join("registrations.ts"))
+                .unwrap_or_default();
+            if has_retention && !registrations.contains("RetentionService") {
+                findings.push(LocalFinding {
+                    severity: Severity::Warning,
+                    project: project.clone(),
+                    check: "retention-wiring".to_string(),
+                    subject: "registrations.ts".to_string(),
+                    message: "entities declare retention policies but RetentionService is not registered — nothing enforces them".to_string(),
+                });
+            }
+            if has_sensitive && !registrations.contains("ComplianceDataService") {
+                findings.push(LocalFinding {
+                    severity: Severity::Warning,
+                    project: project.clone(),
+                    check: "erasure-wiring".to_string(),
+                    subject: "registrations.ts".to_string(),
+                    message: "entities hold classified data but ComplianceDataService is not registered — erasure/export requests cannot be served".to_string(),
+                });
+            }
+
+            // 3. Sensitive-field heuristics
+            for entity in &entities {
+                for (field, classification) in &entity.field_classifications {
+                    if classification != "none" {
+                        continue;
+                    }
+                    if let Some(suggested) = suggest_classification(field) {
+                        findings.push(LocalFinding {
+                            severity: Severity::Info,
+                            project: project.clone(),
+                            check: "possible-misclassification".to_string(),
+                            subject: format!("{}.{}", entity.entity_name, field),
+                            message: format!(
+                                "field name suggests '{}' data but it is classified 'none' — review the classification",
+                                suggested
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Deterministic output for --json / snapshots
+    findings.sort_by(|a, b| {
+        (&a.project, &a.check, &a.subject, &a.message).cmp(&(
+            &b.project,
+            &b.check,
+            &b.subject,
+            &b.message,
+        ))
+    });
+    Ok(findings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_tenant_gates_flags_absent_calls() {
+        let source = "const orm = ci.resolve(tokens.Orm);";
+        let missing = missing_tenant_gates(source);
+        assert_eq!(missing.len(), 2);
+    }
+
+    #[test]
+    fn test_missing_tenant_gates_passes_wired_entrypoint() {
+        let source = r#"
+            setupTenantFilter(orm, { logger });
+            setupRls(orm, { logger });
+        "#;
+        assert!(missing_tenant_gates(source).is_empty());
+    }
+
+    #[test]
+    fn test_suggest_classification_pii_camel_and_snake() {
+        assert_eq!(suggest_classification("email"), Some("pii"));
+        assert_eq!(suggest_classification("userEmail"), Some("pii"));
+        assert_eq!(suggest_classification("first_name"), Some("pii"));
+        assert_eq!(suggest_classification("billingAddress"), Some("pii"));
+        assert_eq!(suggest_classification("dateOfBirth"), Some("pii"));
+        assert_eq!(suggest_classification("birthDate"), Some("pii"));
+    }
+
+    #[test]
+    fn test_suggest_classification_strongest_wins() {
+        assert_eq!(suggest_classification("cardNumber"), Some("pci"));
+        assert_eq!(suggest_classification("ssn"), Some("phi"));
+        assert_eq!(suggest_classification("healthInsuranceNumber"), Some("phi"));
+    }
+
+    #[test]
+    fn test_suggest_classification_avoids_generic_names() {
+        assert_eq!(suggest_classification("name"), None);
+        assert_eq!(suggest_classification("description"), None);
+        assert_eq!(suggest_classification("externalId"), None);
+        assert_eq!(suggest_classification("billingProvider"), None);
+        assert_eq!(suggest_classification("cadence"), None);
+    }
+}
+
+#[cfg(test)]
+mod fs_tests {
+    use super::*;
+
+    #[test]
+    fn test_run_local_checks_flags_unwired_entrypoint() {
+        let dir = std::env::temp_dir().join("fl-checks-test");
+        let proj = dir.join("svc");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(proj.join("persistence")).unwrap();
+        std::fs::write(proj.join("server.ts"), "const app = express();").unwrap();
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(findings.len(), 2, "expected 2 wiring findings, got: {:?}", findings);
+        assert!(findings.iter().all(|f| f.check == "tenant-isolation-wiring"));
+    }
+}

--- a/cli/src/compliance/mod.rs
+++ b/cli/src/compliance/mod.rs
@@ -4,6 +4,7 @@ use clap::{ArgMatches, Command};
 use crate::{CliCommand, core::command::command};
 
 mod audit;
+mod checks;
 
 use audit::AuditCommand;
 

--- a/cli/src/init/worker.rs
+++ b/cli/src/init/worker.rs
@@ -111,7 +111,7 @@ fn generate_basic_worker(
         module_id: None,
     };
 
-    let ignore_files = if !manifest_data.is_database_enabled {
+    let mut ignore_files = if !manifest_data.is_database_enabled {
         vec![
             "mikro-orm.config.ts".to_string(),
             "seeder.ts".to_string(),
@@ -122,6 +122,15 @@ fn generate_basic_worker(
     } else {
         vec!["consts.ts".to_string()]
     };
+    // compliance endpoints authenticate via IAM-issued JWTs
+    // (JWKS_PUBLIC_KEY_URL is only registered when IAM is configured)
+    if !manifest_data.is_iam_configured {
+        for file in ["compliance.controller.ts", "compliance.routes.ts"] {
+            if !ignore_files.iter().any(|f| f == file) {
+                ignore_files.push(file.to_string());
+            }
+        }
+    }
     let mut ignore_dirs = if !manifest_data.is_database_enabled {
         let mut dirs = vec!["seeder".to_string(), "seed.data.ts".to_string()];
         if !manifest_data.with_mappers {

--- a/cli/src/templates/project/worker/worker.ts
+++ b/cli/src/templates/project/worker/worker.ts
@@ -3,7 +3,8 @@ import {
   WorkerProcessFunction
 } from '@forklaunch/interfaces-worker/types';
 import { getEnvVar } from '@forklaunch/common';
-import dotenv from 'dotenv';
+{{#is_database_enabled}}import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
+{{/is_database_enabled}}import dotenv from 'dotenv';
 import { createDependencyContainer } from './registrations';
 {{#is_database_worker}}import type { {{pascal_case_name}}EventRecord } from './persistence/entities';{{/is_database_worker}}{{^is_database_worker}}import type { {{pascal_case_name}}EventRecord } from './domain/types/{{camel_case_name}}EventRecord.types';{{/is_database_worker}}
 
@@ -12,7 +13,13 @@ dotenv.config({ path: envFilePath });
 const { ci, tokens } = createDependencyContainer(envFilePath);
 
 const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
-
+{{#is_database_enabled}}
+//! registers tenant isolation on the worker's ORM so background jobs are
+//! gated the same way as request handling
+const orm = ci.resolve(tokens.Orm);
+setupTenantFilter(orm, { logger: openTelemetryCollector });
+setupRls(orm, { logger: openTelemetryCollector });
+{{/is_database_enabled}}
 const processEvents: WorkerProcessFunction<{{pascal_case_name}}EventRecord> =
   async (events) => {
     const failedEvents = [];

--- a/cli/src/templates/router/api/controllers/{{camel_case_name}}.controller.ts
+++ b/cli/src/templates/router/api/controllers/{{camel_case_name}}.controller.ts
@@ -89,7 +89,7 @@ export const {{camel_case_name}}Post = handlers.post(
       .json(
         // constructs a new service instance using the scopeFactory and calls the {{camel_case_name}}Post method
         await serviceFactory({{#is_worker}}
-          { tenantId: (req.session as Record<string, unknown>)?.organizationId ?? '' }{{/is_worker}}{{^is_worker}}
+          { tenantId: req.session?.organizationId ?? '' }{{/is_worker}}{{^is_worker}}
           { scope: scopeFactory() }{{/is_worker}}
         ).{{camel_case_name}}Post(req.body)
       );

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forklaunch/core",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "forklaunch-js core package. Contains useful building blocks.",
   "homepage": "https://github.com/forklaunch/forklaunch-js#readme",
   "bugs": {

--- a/framework/core/src/http/types/apiDefinition.types.ts
+++ b/framework/core/src/http/types/apiDefinition.types.ts
@@ -99,6 +99,17 @@ export interface ForklaunchBaseRequest<
  * @template ReqQuery - A type for the request query, defaulting to ParsedQs.
  * @template Headers - A type for the request headers, defaulting to IncomingHttpHeaders.
  */
+/**
+ * First-party session claims the platform understands. Multi-tenant
+ * scaffolds read `organizationId` to scope the tenant filter, so it is
+ * typed here rather than cast at every call site. Applications extend the
+ * session further via their `SessionSchema` type parameter.
+ */
+export interface ForklaunchBaseSession {
+  /** Active organization (tenant) for the authenticated session. */
+  organizationId?: string;
+}
+
 export interface ForklaunchRequest<
   SV extends AnySchemaValidator,
   P extends ParamsDictionary,
@@ -153,7 +164,7 @@ export interface ForklaunchRequest<
   openTelemetryCollector?: OpenTelemetryCollector<MetricsDefinition>;
 
   /** Session */
-  session: JWTPayload & SessionSchema;
+  session: JWTPayload & ForklaunchBaseSession & SessionSchema;
 
   /** Parsed versions */
   _parsedVersions: string[] | number;
@@ -930,7 +941,7 @@ export type ExpressLikeAuthMapper<
   SessionSchema extends Record<string, unknown>,
   BaseRequest
 > = (
-  payload: JWTPayload & SessionSchema,
+  payload: JWTPayload & ForklaunchBaseSession & SessionSchema,
   req?: ResolvedForklaunchRequest<
     SV,
     P,


### PR DESCRIPTION
## Summary

Answers "do compliance checks verify the tenant/RLS/retention abstractions are actually wired?" — previously **no**; the audit was a data inventory (entities, routes, secrets, residency) with no wiring verification. Now it gates setup:

### Audit: local checks (offline, deterministic, in `--json` as `localFindings`)
- **tenant-isolation-wiring**: every project owning persistence entities must call `setupTenantFilter` and `setupRls` in each runtime entrypoint (`server.ts` *and* `worker.ts`)
- **retention-wiring** / **erasure-wiring**: entities declaring retention or holding classified data require `RetentionService` / `ComplianceDataService` registrations
- **possible-misclassification**: fields classified `none` whose names match PII/PHI/PCI keyword lists (camelCase/snake_case word-splitting with joined pairs — `first_name`, `cardNumber`, `dateOfBirth` match; `name`, `externalId`, `billingProvider` don't)

### The gap the wiring check immediately caught
Worker entrypoints never wired tenant isolation: `server.ts` templates call `setupTenantFilter`/`setupRls` but `worker.ts` (template + sample-worker) did not — background jobs touched tenant-scoped tables with no isolation active, silently, since the tenant filter is fail-open. Both are now wired (guarded by `is_database_enabled`, mirroring server.ts).

### Related fixes
- `init worker` now skips `compliance.controller.ts`/`compliance.routes.ts` when IAM isn't configured (parity with `init service`) — previously a database worker in a no-IAM app failed typecheck resolving the IAM-gated `JWKS_PUBLIC_KEY_URL` token
- `core@1.5.10`: `ForklaunchBaseSession` types `organizationId` as a first-party session claim; the scaffolded controller's `(req.session as Record<string, unknown>)?.organizationId` cast is now `req.session?.organizationId`

## Test plan
- `cargo test`: 333 passed (new: keyword classifier cases, wiring-gate detection, fs-level check integration)
- Live validation on a fresh scaffold: audit reports 0 findings on a correctly wired app; flags both missing setup calls when stripped from `server.ts`; flags a `contactEmail` field classified `none` as possible PII
- Fresh `init worker -t database` in a no-IAM app now typechecks clean (was TS2339)
- `sample-worker` builds with the wiring change; framework core 371 tests pass with the session type change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline compliance checks for tenant isolation, retention services, and sensitive data classifications.
  * Compliance reports now include local findings with severity indicators and clear all-clear messaging.
  * Worker templates automatically configure tenant filtering and row-level security when database support is enabled.
  * Sessions now support an optional organization identifier.

* **Bug Fixes**
  * Improved generated worker projects when IAM is not configured by excluding irrelevant compliance templates.
  * Improved request handling when session information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->