### PR TITLE
docs(cli): RDS TLS shipped in 1.4.2, not 1.5.0

### DIFF
--- a/cli/docs/RDS_TLS.md
+++ b/cli/docs/RDS_TLS.md
@@ -28,7 +28,7 @@ How it works:
 
 ## Migrating existing apps
 
-Apps generated before CLI 1.5.0 need three things:
+Apps generated before CLI 1.4.2 need three things:
 
 1. Copy the bundle into your repo (path is convention, not requirement):
 


### PR DESCRIPTION
One-line correction: the RDS TLS migration doc referenced 1.5.0; the feature shipped in cli-v1.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RDS TLS migration guidance to apply to applications generated before CLI version 1.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->