### PR TITLE
fix: mikro-orm 7.1.x scaffold hardening — AnyMikroORM, readonly options, age-gate healing

### DIFF
--- a/blueprint/billing-base/package.json
+++ b/blueprint/billing-base/package.json
@@ -40,7 +40,7 @@
     "@forklaunch/blueprint-iam-base": "workspace:^",
     "@forklaunch/blueprint-monitoring": "workspace:^",
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/express": "^1.2.39",
     "@forklaunch/hyper-express": "^1.2.39",
     "@forklaunch/implementation-billing-base": "workspace:^",
@@ -63,7 +63,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@forklaunch/testing": "^1.2.24",
+    "@forklaunch/testing": "^1.2.25",
     "@mikro-orm/cli": "7.1.11",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.3",

--- a/blueprint/billing-stripe/package.json
+++ b/blueprint/billing-stripe/package.json
@@ -42,7 +42,7 @@
     "@forklaunch/blueprint-iam-base": "workspace:^",
     "@forklaunch/blueprint-monitoring": "workspace:^",
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/express": "^1.2.39",
     "@forklaunch/hyper-express": "^1.2.39",
     "@forklaunch/implementation-billing-stripe": "workspace:^",
@@ -66,7 +66,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@forklaunch/testing": "^1.2.24",
+    "@forklaunch/testing": "^1.2.25",
     "@mikro-orm/cli": "7.1.11",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.3",

--- a/blueprint/client-sdk/package.json
+++ b/blueprint/client-sdk/package.json
@@ -27,6 +27,6 @@
     "@forklaunch/blueprint-iam-base": "workspace:^",
     "@forklaunch/blueprint-iam-better-auth": "workspace:^",
     "@forklaunch/blueprint-sample-worker": "workspace:^",
-    "@forklaunch/core": "^1.5.12"
+    "@forklaunch/core": "^1.5.13"
   }
 }

--- a/blueprint/core/package.json
+++ b/blueprint/core/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/express": "^1.2.39",
     "@forklaunch/hyper-express": "^1.2.39",
     "@forklaunch/validator": "^1.2.24",

--- a/blueprint/ecommerce-stripe/package.json
+++ b/blueprint/ecommerce-stripe/package.json
@@ -36,7 +36,7 @@
     "@forklaunch/blueprint-iam-base": "workspace:^",
     "@forklaunch/blueprint-monitoring": "workspace:^",
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/express": "^1.2.39",
     "@forklaunch/hyper-express": "^1.2.39",
     "@forklaunch/infrastructure-redis": "^1.4.10",
@@ -58,7 +58,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@forklaunch/testing": "^1.2.24",
+    "@forklaunch/testing": "^1.2.25",
     "@mikro-orm/cli": "7.1.11",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.3",

--- a/blueprint/iam-base/package.json
+++ b/blueprint/iam-base/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@forklaunch/blueprint-core": "workspace:^",
     "@forklaunch/blueprint-monitoring": "workspace:^",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/hyper-express-fork": "^6.17.35",
     "@forklaunch/implementation-iam-base": "workspace:^",
     "@forklaunch/interfaces-iam": "workspace:^",
@@ -59,7 +59,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@forklaunch/testing": "^1.2.24",
+    "@forklaunch/testing": "^1.2.25",
     "@mikro-orm/cli": "7.1.11",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.3",

--- a/blueprint/iam-better-auth/package.json
+++ b/blueprint/iam-better-auth/package.json
@@ -39,7 +39,7 @@
     "@forklaunch/blueprint-core": "workspace:^",
     "@forklaunch/blueprint-iam-base": "workspace:^",
     "@forklaunch/blueprint-monitoring": "workspace:^",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/implementation-iam-base": "workspace:^",
     "@forklaunch/interfaces-iam": "workspace:^",
     "@mikro-orm/core": "7.1.11",
@@ -59,7 +59,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@forklaunch/testing": "^1.2.24",
+    "@forklaunch/testing": "^1.2.25",
     "@mikro-orm/cli": "7.1.11",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.3",

--- a/blueprint/implementations/billing/base/package.json
+++ b/blueprint/implementations/billing/base/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-billing": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@forklaunch/validator": "^1.2.24",

--- a/blueprint/implementations/billing/stripe/package.json
+++ b/blueprint/implementations/billing/stripe/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/implementation-billing-base": "workspace:^",
     "@forklaunch/interfaces-billing": "workspace:^",
     "@forklaunch/internal": "^1.2.24",

--- a/blueprint/implementations/ecommerce/base/package.json
+++ b/blueprint/implementations/ecommerce/base/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-ecommerce": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@forklaunch/validator": "^1.2.24",

--- a/blueprint/implementations/iam/base/package.json
+++ b/blueprint/implementations/iam/base/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-iam": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@forklaunch/validator": "^1.2.24",

--- a/blueprint/implementations/worker/bullmq/package.json
+++ b/blueprint/implementations/worker/bullmq/package.json
@@ -66,7 +66,7 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-worker": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@sinclair/typebox": "^0.34.52",

--- a/blueprint/implementations/worker/database/package.json
+++ b/blueprint/implementations/worker/database/package.json
@@ -66,7 +66,7 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-worker": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@mikro-orm/core": "7.1.11",

--- a/blueprint/implementations/worker/kafka/package.json
+++ b/blueprint/implementations/worker/kafka/package.json
@@ -66,7 +66,7 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-worker": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@sinclair/typebox": "^0.34.52",

--- a/blueprint/implementations/worker/redis/package.json
+++ b/blueprint/implementations/worker/redis/package.json
@@ -66,7 +66,7 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/interfaces-worker": "workspace:^",
     "@forklaunch/internal": "^1.2.24",
     "@sinclair/typebox": "^0.34.52",

--- a/blueprint/monitoring/package.json
+++ b/blueprint/monitoring/package.json
@@ -25,7 +25,7 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/core": "^1.5.12"
+    "@forklaunch/core": "^1.5.13"
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260707.2"

--- a/blueprint/package.json
+++ b/blueprint/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@forklaunch/common": "^1.2.23",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/express": "^1.2.39",
     "@forklaunch/hyper-express": "^1.2.39",
     "@forklaunch/universal-sdk": "^1.2.24",

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@forklaunch/core': ^1.5.12
+  '@forklaunch/core': ^1.5.13
 
 importers:
 
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/express':
         specifier: ^1.2.39
         version: 1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(jose@6.2.8)(zod@4.4.3)
@@ -100,8 +100,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/express':
         specifier: ^1.2.39
         version: 1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(jose@6.2.8)(zod@4.4.3)
@@ -164,8 +164,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@forklaunch/testing':
-        specifier: ^1.2.24
-        version: 1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
+        specifier: ^1.2.25
+        version: 1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
       '@mikro-orm/cli':
         specifier: 7.1.11
         version: 7.1.11
@@ -221,8 +221,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/express':
         specifier: ^1.2.39
         version: 1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(jose@6.2.8)(zod@4.4.3)
@@ -288,8 +288,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@forklaunch/testing':
-        specifier: ^1.2.24
-        version: 1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
+        specifier: ^1.2.25
+        version: 1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
       '@mikro-orm/cli':
         specifier: 7.1.11
         version: 7.1.11
@@ -336,8 +336,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/express':
         specifier: ^1.2.39
         version: 1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(jose@6.2.8)(zod@4.4.3)
@@ -391,8 +391,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/express':
         specifier: ^1.2.39
         version: 1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(jose@6.2.8)(zod@4.4.3)
@@ -452,8 +452,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@forklaunch/testing':
-        specifier: ^1.2.24
-        version: 1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
+        specifier: ^1.2.25
+        version: 1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
       '@mikro-orm/cli':
         specifier: 7.1.11
         version: 7.1.11
@@ -503,8 +503,8 @@ importers:
         specifier: workspace:^
         version: link:../monitoring
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/hyper-express-fork':
         specifier: ^6.17.35
         version: 6.17.35
@@ -561,8 +561,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@forklaunch/testing':
-        specifier: ^1.2.24
-        version: 1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
+        specifier: ^1.2.25
+        version: 1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
       '@mikro-orm/cli':
         specifier: 7.1.11
         version: 7.1.11
@@ -612,8 +612,8 @@ importers:
         specifier: workspace:^
         version: link:../monitoring
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-iam-base':
         specifier: workspace:^
         version: link:../implementations/iam/base
@@ -667,8 +667,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@forklaunch/testing':
-        specifier: ^1.2.24
-        version: 1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
+        specifier: ^1.2.25
+        version: 1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
       '@mikro-orm/cli':
         specifier: 7.1.11
         version: 7.1.11
@@ -709,8 +709,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-billing':
         specifier: workspace:^
         version: link:../../../interfaces/billing
@@ -752,8 +752,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-billing-base':
         specifier: workspace:^
         version: link:../base
@@ -801,8 +801,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-ecommerce':
         specifier: workspace:^
         version: link:../../../interfaces/ecommerce
@@ -844,8 +844,8 @@ importers:
         specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-iam':
         specifier: workspace:^
         version: link:../../../interfaces/iam
@@ -887,8 +887,8 @@ importers:
   implementations/worker/bullmq:
     dependencies:
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-worker':
         specifier: workspace:^
         version: link:../../../interfaces/worker
@@ -927,8 +927,8 @@ importers:
   implementations/worker/database:
     dependencies:
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-worker':
         specifier: workspace:^
         version: link:../../../interfaces/worker
@@ -967,8 +967,8 @@ importers:
   implementations/worker/kafka:
     dependencies:
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-worker':
         specifier: workspace:^
         version: link:../../../interfaces/worker
@@ -1007,8 +1007,8 @@ importers:
   implementations/worker/redis:
     dependencies:
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/interfaces-worker':
         specifier: workspace:^
         version: link:../../../interfaces/worker
@@ -1131,8 +1131,8 @@ importers:
   monitoring:
     dependencies:
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
     devDependencies:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260707.2
@@ -1147,8 +1147,8 @@ importers:
         specifier: workspace:^
         version: link:../monitoring
       '@forklaunch/core':
-        specifier: ^1.5.12
-        version: 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.13
+        version: 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-worker-bullmq':
         specifier: workspace:^
         version: link:../implementations/worker/bullmq
@@ -1235,8 +1235,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@forklaunch/testing':
-        specifier: ^1.2.24
-        version: 1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
+        specifier: ^1.2.25
+        version: 1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))
       '@mikro-orm/cli':
         specifier: 7.1.11
         version: 7.1.11
@@ -2164,8 +2164,8 @@ packages:
   '@forklaunch/common@1.2.23':
     resolution: {integrity: sha512-KbKY+mL5VJGTM2XH0nufTfNgXuguMqJewVPgQmV6pp16IAa6dFZkqXiib87csuOXjUyt1QxJmolMhgx0mln0cQ==}
 
-  '@forklaunch/core@1.5.12':
-    resolution: {integrity: sha512-ujfIYjG4e0yvZY3YKL/G0S/5QADAOQ165nevYZcaRKEM/pAJcdrOjbQPtWOUgPiEfHt0UT39LfI6PPXLSAGRTg==}
+  '@forklaunch/core@1.5.13':
+    resolution: {integrity: sha512-GF2HE5OHD6dbCGwBHeNK7ayZPtNiclFBk7MEG4Msoe8ijxc1eNvFQf/zDfHIIlhbd0dZp5f7Jajey3buTOTcxg==}
 
   '@forklaunch/express@1.2.39':
     resolution: {integrity: sha512-zUIN80L++cVa0d8+w2QzI/UKYTusTFYbIgosldS1ajpQtbjdpDnH/xdPx56cyNWoPO/H4R+vmnqmSd2dfH8w0w==}
@@ -2191,8 +2191,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@forklaunch/testing@1.2.24':
-    resolution: {integrity: sha512-LLs2UAmoAbtMGwHgYY8/ncdThvBmI4qtYq2nM68oFV8l32AGNSGjX0JByM2RTpJGzKv11uyt0s9ej5S9HbbDOQ==}
+  '@forklaunch/testing@1.2.25':
+    resolution: {integrity: sha512-2nQUA/mUNGd417kUt+DhqWdAGZXXIL0pyy97fhUv3pX65HkXY8im6jS6Vnp7xBsK2xF2X1RKcJ/GbtztM3VCDw==}
     peerDependencies:
       vitest: ^3.0.0
 
@@ -8804,7 +8804,7 @@ snapshots:
 
   '@forklaunch/common@1.2.23': {}
 
-  '@forklaunch/core@1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)':
+  '@forklaunch/core@1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)':
     dependencies:
       '@asyncapi/parser': 3.6.3
       '@forklaunch/common': 1.2.23
@@ -8860,7 +8860,7 @@ snapshots:
   '@forklaunch/express@1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(jose@6.2.8)(zod@4.4.3)':
     dependencies:
       '@forklaunch/common': 1.2.23
-      '@forklaunch/core': 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/core': 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/validator': 1.2.24
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@scalar/express-api-reference': 0.10.13
@@ -8912,7 +8912,7 @@ snapshots:
   '@forklaunch/hyper-express@1.2.39(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(express@5.2.1)':
     dependencies:
       '@forklaunch/common': 1.2.23
-      '@forklaunch/core': 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/core': 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/hyper-express-fork': 6.17.35
       '@forklaunch/validator': 1.2.24
       '@forklaunch/ws': 1.2.38(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
@@ -8950,7 +8950,7 @@ snapshots:
   '@forklaunch/infrastructure-redis@1.4.10(@opentelemetry/api@1.9.1)(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)':
     dependencies:
       '@forklaunch/common': 1.2.23
-      '@forklaunch/core': 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/core': 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       redis: 6.2.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -8977,7 +8977,7 @@ snapshots:
     dependencies:
       '@aws-sdk/client-s3': 3.1106.0
       '@forklaunch/common': 1.2.23
-      '@forklaunch/core': 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/core': 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@cfworker/json-schema'
@@ -9016,7 +9016,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@forklaunch/testing@1.2.24(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))':
+  '@forklaunch/testing@1.2.25(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.2.0)(esbuild@0.27.7)(tsx@4.23.12)(yaml@2.9.0)))':
     dependencies:
       '@mikro-orm/core': 7.1.11
       ioredis: 6.0.0
@@ -9046,7 +9046,7 @@ snapshots:
     dependencies:
       '@asyncapi/parser': 3.6.3
       '@forklaunch/common': 1.2.23
-      '@forklaunch/core': 1.5.12(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/core': 1.5.13(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/validator': 1.2.24
       '@types/ws': 8.18.1
       ws: 8.21.3

--- a/blueprint/pnpm-workspace.yaml
+++ b/blueprint/pnpm-workspace.yaml
@@ -42,4 +42,4 @@ allowBuilds:
   unrs-resolver: true
 
 overrides:
-  "@forklaunch/core": ^1.5.12
+  "@forklaunch/core": ^1.5.13

--- a/blueprint/sample-worker/package.json
+++ b/blueprint/sample-worker/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@forklaunch/blueprint-core": "workspace:^",
     "@forklaunch/blueprint-monitoring": "workspace:^",
-    "@forklaunch/core": "^1.5.12",
+    "@forklaunch/core": "^1.5.13",
     "@forklaunch/implementation-worker-bullmq": "workspace:^",
     "@forklaunch/implementation-worker-database": "workspace:^",
     "@forklaunch/implementation-worker-kafka": "workspace:^",
@@ -71,7 +71,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@forklaunch/testing": "^1.2.24",
+    "@forklaunch/testing": "^1.2.25",
     "@mikro-orm/cli": "7.1.11",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.3",

--- a/cli/src/core/package_json/package_json_constants.rs
+++ b/cli/src/core/package_json/package_json_constants.rs
@@ -234,7 +234,7 @@ pub(crate) const BUNRUN_VERSION: &str = "~0.0.2";
 // @forklaunch/common
 pub(crate) const COMMON_VERSION: &str = "~1.2.23";
 // @forklaunch/core
-pub(crate) const CORE_VERSION: &str = "~1.5.12";
+pub(crate) const CORE_VERSION: &str = "~1.5.13";
 // @forklaunch/express
 pub(crate) const EXPRESS_VERSION: &str = "~1.2.39";
 // @forklaunch/hyper-express
@@ -266,7 +266,7 @@ pub(crate) const WORKER_INTERFACES_VERSION: &str = "~1.0.29";
 // @forklaunch/internal
 pub(crate) const INTERNAL_VERSION: &str = "~1.2.24";
 // @forklaunch/testing
-pub(crate) const TESTING_VERSION: &str = "~1.2.24";
+pub(crate) const TESTING_VERSION: &str = "~1.2.25";
 // @forklaunch/universal-sdk
 pub(crate) const UNIVERSAL_SDK_VERSION: &str = "~1.2.24";
 // @forklaunch/validator

--- a/cli/src/core/pnpm_workspace.rs
+++ b/cli/src/core/pnpm_workspace.rs
@@ -78,6 +78,44 @@ fn sanitize_allow_builds(pnpm_workspace: &mut PnpmWorkspace) {
     pnpm_workspace.allow_builds = Some(allow_builds);
 }
 
+/// Tooling (e.g. Studio upgrade flows) writes version-pinned entries like
+/// `@forklaunch/core@1.5.9` into `minimumReleaseAgeExclude`. After a
+/// framework release those pins go stale: pnpm blocks the new version with
+/// ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION and in-range resolution falls back
+/// to the old one. First-party packages should always be exempt from the age
+/// gate, so strip version suffixes down to bare package names on every
+/// rewrite.
+fn sanitize_minimum_release_age_exclude(pnpm_workspace: &mut PnpmWorkspace) {
+    let Some(Value::Sequence(entries)) =
+        pnpm_workspace.other.get_mut("minimumReleaseAgeExclude")
+    else {
+        return;
+    };
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut normalized: Vec<Value> = Vec::new();
+    for entry in entries.iter() {
+        match entry {
+            Value::String(spec) if spec.starts_with("@forklaunch/") => {
+                // find a version separator after the scope's leading '@'
+                let name = match spec[1..].find('@') {
+                    Some(index) => spec[..index + 1].to_string(),
+                    None => spec.clone(),
+                };
+                if seen.insert(name.clone()) {
+                    normalized.push(Value::String(name));
+                }
+            }
+            Value::String(spec) => {
+                if seen.insert(spec.clone()) {
+                    normalized.push(entry.clone());
+                }
+            }
+            _ => normalized.push(entry.clone()),
+        }
+    }
+    *entries = normalized;
+}
+
 pub(crate) fn generate_pnpm_workspace(
     application_path: &str,
     additional_projects: &Vec<ProjectEntry>,
@@ -122,6 +160,7 @@ pub(crate) fn render_pnpm_workspace_with_packages(
     };
     pnpm_workspace.packages = packages;
     sanitize_allow_builds(&mut pnpm_workspace);
+    sanitize_minimum_release_age_exclude(&mut pnpm_workspace);
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE)?)
 }
@@ -142,6 +181,7 @@ pub(crate) fn add_project_definition_to_pnpm_workspace<
         pnpm_workspace.packages.push(manifest_data.name().clone());
     }
     sanitize_allow_builds(&mut pnpm_workspace);
+    sanitize_minimum_release_age_exclude(&mut pnpm_workspace);
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_PNPM_WORKSPACE)?)
 }
@@ -164,7 +204,35 @@ pub(crate) fn remove_project_definition_to_pnpm_workspace(
         pnpm_workspace.packages.remove(position);
     }
     sanitize_allow_builds(&mut pnpm_workspace);
+    sanitize_minimum_release_age_exclude(&mut pnpm_workspace);
 
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_PNPM_WORKSPACE)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_minimum_release_age_exclude_strips_forklaunch_versions() {
+        let mut ws: PnpmWorkspace = from_str(
+            "packages:\n- core\nminimumReleaseAgeExclude:\n- '@forklaunch/core@1.5.9'\n- '@forklaunch/express@1.2.37'\n- '@forklaunch/core@1.5.10'\n- 'left-pad@1.3.0'\n",
+        )
+        .unwrap();
+        sanitize_minimum_release_age_exclude(&mut ws);
+        let rendered = to_string(&ws).unwrap();
+        assert!(rendered.contains("- '@forklaunch/core'"));
+        assert!(rendered.contains("- '@forklaunch/express'"));
+        // duplicates collapse, non-forklaunch entries untouched
+        assert_eq!(rendered.matches("@forklaunch/core").count(), 1);
+        assert!(rendered.contains("left-pad@1.3.0"));
+    }
+
+    #[test]
+    fn test_minimum_release_age_exclude_absent_is_noop() {
+        let mut ws: PnpmWorkspace = from_str("packages:\n- core\n").unwrap();
+        sanitize_minimum_release_age_exclude(&mut ws);
+        assert!(!to_string(&ws).unwrap().contains("minimumReleaseAgeExclude"));
+    }
 }

--- a/cli/src/templates/project/service/__test__/test-utils.ts
+++ b/cli/src/templates/project/service/__test__/test-utils.ts
@@ -1,12 +1,13 @@
 import { getEnvVar } from '@forklaunch/common';
 import {
-  BlueprintTestHarness,
+  {{#is_database_enabled}}AnyMikroORM,
+  {{/is_database_enabled}}BlueprintTestHarness,
   clearTestDatabase,
   {{#is_database_enabled}}DatabaseType,
   {{/is_database_enabled}}TEST_TOKENS,
   TestSetupResult
 } from '@forklaunch/testing';
-{{#is_database_enabled}}import { EntityManager, MikroORM } from '@mikro-orm/core';{{/is_database_enabled}}
+{{#is_database_enabled}}import { EntityManager } from '@mikro-orm/core';{{/is_database_enabled}}
 import dotenv from 'dotenv';
 import * as path from 'path';
 
@@ -42,7 +43,7 @@ export const cleanupTestDatabase = async (): Promise<void> => {
 };
 
 export const clearDatabase = async (options?: {
-  {{#is_database_enabled}}orm?: MikroORM;
+  {{#is_database_enabled}}orm?: AnyMikroORM;
   {{/is_database_enabled}}redis?: TestSetupResult['redis'];
 }): Promise<void> => {
   await clearTestDatabase(options);

--- a/cli/src/templates/project/worker/__test__/test-utils.ts
+++ b/cli/src/templates/project/worker/__test__/test-utils.ts
@@ -1,12 +1,13 @@
 import { getEnvVar } from '@forklaunch/common';
 import {
-  BlueprintTestHarness,
+  {{#is_database_enabled}}AnyMikroORM,
+  {{/is_database_enabled}}BlueprintTestHarness,
   clearTestDatabase,
   {{#is_database_enabled}}DatabaseType,
   {{/is_database_enabled}}TEST_TOKENS,
   TestSetupResult
 } from '@forklaunch/testing';
-{{#is_database_enabled}}import { EntityManager, MikroORM } from '@mikro-orm/core';
+{{#is_database_enabled}}import { EntityManager } from '@mikro-orm/core';
 {{/is_database_enabled}}import dotenv from 'dotenv';
 import * as path from 'path';
 
@@ -51,7 +52,7 @@ export const cleanupTestDatabase = async (): Promise<void> => {
 };
 
 export const clearDatabase = async (options?: {
-  {{#is_database_enabled}}orm?: MikroORM;
+  {{#is_database_enabled}}orm?: AnyMikroORM;
   {{/is_database_enabled}}redis?: TestSetupResult['redis'];
 }): Promise<void> => {
   await clearTestDatabase(options);

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forklaunch/core",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "forklaunch-js core package. Contains useful building blocks.",
   "homepage": "https://github.com/forklaunch/forklaunch-js#readme",
   "bugs": {

--- a/framework/core/src/persistence/index.ts
+++ b/framework/core/src/persistence/index.ts
@@ -56,6 +56,8 @@ export {
 // PostgreSQL Row-Level Security
 export { setupRls, RlsEventSubscriber, type RlsConfig } from './rls';
 
+export type { AnyMikroORM } from './mikroOrm.types';
+
 // Tenant-scoped EM proxy (wraps every operation in withEncryptionContext to
 // survive AsyncLocalStorage propagation through pg connection pool callbacks)
 export { wrapEmWithTenantContext } from './tenantEm';

--- a/framework/core/src/persistence/mikroOrm.types.ts
+++ b/framework/core/src/persistence/mikroOrm.types.ts
@@ -1,0 +1,23 @@
+import type { MikroORM } from '@mikro-orm/core';
+
+/**
+ * `MikroORM` with relaxed type parameters.
+ *
+ * MikroORM 7.1+ types the third generic as
+ * `Entities extends readonly (...)[]` with a *mutable* array default, so
+ * `MikroORM.init()` / `new MikroORM(defineConfig(...))` produce instances
+ * whose readonly entities tuple is not assignable to a bare `MikroORM`
+ * annotation. Use this alias for ORM-valued parameters, fields, and
+ * variables that must accept any configured instance.
+ *
+ * @example
+ * ```typescript
+ * import { AnyMikroORM } from '@forklaunch/core/persistence';
+ *
+ * function withOrm(orm: AnyMikroORM) {
+ *   return orm.em.fork();
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyMikroORM = MikroORM<any, any, any>;

--- a/framework/testing/package.json
+++ b/framework/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forklaunch/testing",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Testing utilities for forklaunch-js blueprints including testcontainer management",
   "homepage": "https://github.com/forklaunch/forklaunch-js#readme",
   "bugs": {

--- a/framework/testing/src/database.ts
+++ b/framework/testing/src/database.ts
@@ -12,11 +12,20 @@ import Redis from 'ioredis';
 import { StartedTestContainer } from 'testcontainers';
 import { DatabaseType } from './containers';
 
+/**
+ * MikroORM options that accept both mutable and readonly (defineConfig-
+ * inferred) shapes. MikroORM 7.1+ infers `entities` as a readonly tuple,
+ * which is not assignable to the mutable array in a bare `Partial<Options>`.
+ */
+export type AnyMikroOrmOptions = Partial<Omit<Options, 'entities'>> & {
+  entities?: readonly NonNullable<Options['entities']>[number][];
+};
+
 export interface MikroOrmTestConfig {
   /**
    * MikroORM config object (imported from mikro-orm.config)
    */
-  mikroOrmConfig: Partial<Options>;
+  mikroOrmConfig: AnyMikroOrmOptions;
 
   /**
    * Database type (postgres, mysql, mongodb, etc.)
@@ -81,7 +90,7 @@ export async function setupTestORM(
   const dbPort = getDatabasePort(databaseType);
 
   // SQLite databases are file-based
-  let ormConfig: Partial<Options> = {};
+  let ormConfig: AnyMikroOrmOptions = {};
   if (databaseType === 'sqlite' || databaseType === 'libsql') {
     ormConfig = {
       ...mikroOrmConfig,

--- a/framework/testing/src/harness.ts
+++ b/framework/testing/src/harness.ts
@@ -1,8 +1,12 @@
-import { Options } from '@mikro-orm/core';
 import Redis from 'ioredis';
 import { StartedTestContainer } from 'testcontainers';
 import { DatabaseType, TestContainerManager } from './containers';
-import { AnyMikroORM, clearTestDatabase, setupTestORM } from './database';
+import {
+  AnyMikroORM,
+  AnyMikroOrmOptions,
+  clearTestDatabase,
+  setupTestORM
+} from './database';
 import { setupTestEnvironment } from './environment';
 
 export interface BlueprintTestConfig {
@@ -11,7 +15,7 @@ export interface BlueprintTestConfig {
    * This is called AFTER environment variables are set
    * Optional - if not provided, no database will be set up
    */
-  getConfig?: () => Promise<Partial<Options>>;
+  getConfig?: () => Promise<AnyMikroOrmOptions>;
 
   /**
    * Database type (postgres, mysql, mongodb, etc.)

--- a/framework/testing/src/index.ts
+++ b/framework/testing/src/index.ts
@@ -26,7 +26,9 @@ export { setupTestEnvironment, TestEnvConfig } from './environment';
 export {
   clearTestDatabase,
   MikroOrmTestConfig,
-  setupTestORM
+  setupTestORM,
+  type AnyMikroORM,
+  type AnyMikroOrmOptions
 } from './database';
 
 export {


### PR DESCRIPTION
## Summary

Response to the four reported scaffold bugs on mikro-orm 7.1.x (readonly entities generics).

**Audit result first:** bugs 1–3 as filed do **not reproduce** on current main + current published packages — a fresh `init application -m billing-stripe -m iam-base` typechecks with zero errors, because the entity/constraint alignment (nullable drift, DTO/schema optionality) and the `AnyMikroORM` relaxations shipped across framework 1.5.11–1.5.12 / implementation 1.0.30/1.1.30 / CLI 1.4.4. The reporter was on the pre-alignment versions. What remains valid from the report is the requested hardening, all implemented here:

- **Bug 1 (requested alias):** `@forklaunch/core@1.5.13` exports `AnyMikroORM` from `/persistence` — the documented type for ORM-valued params/fields that must accept `MikroORM.init()` instances
- **Bug 2:** `@forklaunch/testing@1.2.25` adds `AnyMikroOrmOptions` (accepts `defineConfig`'s readonly `entities`) for `BlueprintTestHarness.getConfig` and `MikroOrmTestConfig`, and exports `AnyMikroORM`/`AnyMikroOrmOptions` at package level; service/worker `test-utils` templates now type `orm` as `AnyMikroORM`
- **Bug 3:** not reproducible (see audit); billing templates already carry the constraint alignment
- **Bug 4:** `forklaunch upgrade`/`minimumReleaseAgeExclude` generation is not in this repo (platform-side), but every CLI workspace-yaml rewrite now **heals** stale entries: versioned `@forklaunch/*@x.y.z` exclusions normalize to bare package names (first-party packages are always exempt from the age gate), deduped, third-party entries untouched. Unit-tested and verified live: injected `@forklaunch/core@1.5.9` pins normalized on the next `init service`

## Verification
- Fresh scaffold (billing-stripe module): `tsgo --noEmit` clean in core and billing including `__test__`
- Live healing repro: stale pins → bare names after `init service`, `left-pad@1.3.0` preserved
- `cargo test`: 335 passed (2 new); core 371 tests pass; scaffold floors synced via `check_blueprint_deps --fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for flexible ORM configurations and entity definitions in database testing utilities.
  - Improved compatibility of generated service and worker test helpers with configured ORM instances.
  - Workspace package exclusions now automatically normalize versioned entries and remove duplicates.

- **Maintenance**
  - Updated core and testing components to their latest patch releases across project blueprints and generated projects.
  - Refreshed generated dependency versions to keep new projects aligned with current framework releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->